### PR TITLE
Clyde Customizations and other improvements

### DIFF
--- a/Aliucord/build.gradle
+++ b/Aliucord/build.gradle
@@ -13,12 +13,11 @@ def getGitHash = { ->
 }
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 
@@ -41,9 +40,9 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.2.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'com.google.android.material:material:1.3.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
     api project(':DiscordStubs')
 }

--- a/Aliucord/src/main/AndroidManifest.xml
+++ b/Aliucord/src/main/AndroidManifest.xml
@@ -1,4 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.aliucord">
-</manifest>
+<manifest package="com.aliucord" />

--- a/Aliucord/src/main/java/com/aliucord/Utils.java
+++ b/Aliucord/src/main/java/com/aliucord/Utils.java
@@ -97,10 +97,19 @@ public class Utils {
         return choice;
     }
 
-    public static User CLYDE = new User(
+    public static User buildClyde(String name, String avatarUrl) {
+        if (name == null) {
+            name = "Clyde";
+        }
+
+        if (avatarUrl == null) {
+            avatarUrl = "https://canary.discord.com/assets/f78426a064bc9dd24847519259bc42af.png";
+        }
+
+        return new User(
             -1,
-            "Clyde",
-            new UserAvatar.Avatar("https://canary.discord.com/assets/f78426a064bc9dd24847519259bc42af.png"),
+            name,
+            new UserAvatar.Avatar(avatarUrl),
             "0000",
             0,
             null,
@@ -117,7 +126,8 @@ public class Utils {
             null,
             null,
             null
-    );
+        );
+    }
 
     /** @deprecated Use ReflectUtils */
     @Deprecated

--- a/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
+++ b/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
@@ -8,7 +8,6 @@ package com.aliucord.api;
 import android.os.Handler;
 import android.os.Looper;
 
-import com.aliucord.CollectionUtils;
 import com.aliucord.Main;
 import com.aliucord.Utils;
 import com.aliucord.utils.ReflectUtils;
@@ -49,6 +48,8 @@ public class CommandsAPI {
         public String content;
         public List<MessageEmbed> embeds;
         public boolean send;
+        public String name;
+        public String avatarUrl;
 
         public CommandResult() { this(null); }
         public CommandResult(String content) {
@@ -57,6 +58,19 @@ public class CommandsAPI {
         public CommandResult(String content, List<MessageEmbed> embeds, boolean send) {
             this.content = content;
             this.embeds = embeds;
+            this.send = send;
+        }
+        public CommandResult(String content, List<MessageEmbed> embeds, String name, boolean send) {
+            this.content = content;
+            this.embeds = embeds;
+            this.name = name;
+            this.send = send;
+        }
+        public CommandResult(String content, List<MessageEmbed> embeds, String name, String avatarUrl, boolean send) {
+            this.content = content;
+            this.embeds = embeds;
+            this.name = name;
+            this.avatarUrl = avatarUrl;
             this.send = send;
         }
     }
@@ -84,7 +98,7 @@ public class CommandsAPI {
             long channelId = StoreStream.getChannelsSelected().getId();
             User me = StoreStream.getUsers().getMe();
             ModelMessage message = ModelMessage.createLocalApplicationCommandMessage(
-                    id, name, channelId, UserUtils.INSTANCE.synthesizeApiUser(me), Utils.CLYDE, false, true, id, clock);
+                    id, name, channelId, UserUtils.INSTANCE.synthesizeApiUser(me), Utils.buildClyde(null, null), false, true, id, clock);
             Class<ModelMessage> c = ModelMessage.class;
             try {
                 ReflectUtils.setField(c, message, "flags", 192L, true);
@@ -119,6 +133,7 @@ public class CommandsAPI {
                         ReflectUtils.setField(c, message, "content", res.content, true);
                         ReflectUtils.setField(c, message, "embeds", res.embeds, true);
                         ReflectUtils.setField(c, message, "flags", 64L, true);
+                        ReflectUtils.setField(c, message, "author", Utils.buildClyde(res.name, res.avatarUrl), true);
                         Utils.rerenderChat(); // TODO: figure out how to rerender single message
                     } catch (Throwable ignored) {}
                 } else {

--- a/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
+++ b/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
@@ -66,7 +66,7 @@ public class CommandsAPI {
             this.name = name;
             this.send = send;
         }
-        public CommandResult(String content, List<MessageEmbed> embeds, String name, String avatarUrl, boolean send) {
+        public CommandResult(String content, List<MessageEmbed> embeds, boolean send, String username, String avatarUrl) {
             this.content = content;
             this.embeds = embeds;
             this.name = name;

--- a/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
+++ b/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
@@ -48,7 +48,7 @@ public class CommandsAPI {
         public String content;
         public List<MessageEmbed> embeds;
         public boolean send;
-        public String name;
+        public String username;
         public String avatarUrl;
 
         public CommandResult() { this(null); }
@@ -60,16 +60,16 @@ public class CommandsAPI {
             this.embeds = embeds;
             this.send = send;
         }
-        public CommandResult(String content, List<MessageEmbed> embeds, String name, boolean send) {
+        public CommandResult(String content, List<MessageEmbed> embeds, boolean send, String username) {
             this.content = content;
             this.embeds = embeds;
-            this.name = name;
+            this.username = username;
             this.send = send;
         }
         public CommandResult(String content, List<MessageEmbed> embeds, boolean send, String username, String avatarUrl) {
             this.content = content;
             this.embeds = embeds;
-            this.name = name;
+            this.username = username;
             this.avatarUrl = avatarUrl;
             this.send = send;
         }
@@ -133,7 +133,7 @@ public class CommandsAPI {
                         ReflectUtils.setField(c, message, "content", res.content, true);
                         ReflectUtils.setField(c, message, "embeds", res.embeds, true);
                         ReflectUtils.setField(c, message, "flags", 64L, true);
-                        ReflectUtils.setField(c, message, "author", Utils.buildClyde(res.name, res.avatarUrl), true);
+                        ReflectUtils.setField(c, message, "author", Utils.buildClyde(res.username, res.avatarUrl), true);
                         Utils.rerenderChat(); // TODO: figure out how to rerender single message
                     } catch (Throwable ignored) {}
                 } else {

--- a/Aliucord/src/main/java/com/aliucord/entities/MessageEmbed.java
+++ b/Aliucord/src/main/java/com/aliucord/entities/MessageEmbed.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021 Juby210
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.entities;
+
+import com.discord.api.message.embed.*;
+import com.discord.api.utcdatetime.UtcDateTime;
+
+import java.util.List;
+
+/** @deprecated Use MessageEmbedBuilder instead */
+@Deprecated
+@SuppressWarnings("unused")
+public class MessageEmbed extends MessageEmbedBuilder {
+    public MessageEmbed() { super(); }
+
+    public MessageEmbed(EmbedType type) { super(type); }
+
+    @Override
+    public MessageEmbed setAuthor(String name, String iconUrl, String url) {
+        return (MessageEmbed) super.setAuthor(name, iconUrl, url);
+    }
+
+    @Override
+    public MessageEmbed setAuthor(EmbedAuthor v) {
+        return (MessageEmbed) super.setAuthor(v);
+    }
+
+    @Override
+    public MessageEmbed setColor(Integer v) {
+        return (MessageEmbed) super.setColor(v);
+    }
+
+    @Override
+    public MessageEmbed setDescription(String v) {
+        return (MessageEmbed) super.setDescription(v);
+    }
+
+    @Override
+    public MessageEmbed addField(String name, String value, boolean inline) {
+        return (MessageEmbed) super.addField(name, value, inline);
+    }
+
+    @Override
+    public MessageEmbed addField(EmbedField v) {
+        return (MessageEmbed) super.addField(v);
+    }
+
+    @Override
+    public MessageEmbed setFields(List<EmbedField> v) {
+        return (MessageEmbed) super.setFields(v);
+    }
+
+    @Override
+    public MessageEmbed setFooter(String text, String iconUrl) {
+        return (MessageEmbed) super.setFooter(text, iconUrl);
+    }
+
+    @Override
+    public MessageEmbed setFooter(EmbedFooter v) {
+        return (MessageEmbed) super.setFooter(v);
+    }
+
+    @Override
+    public MessageEmbed setImage(EmbedImage v) {
+        return (MessageEmbed) super.setImage(v);
+    }
+
+    @Override
+    public MessageEmbed setProvider(EmbedProvider v) {
+        return (MessageEmbed) super.setProvider(v);
+    }
+
+    @Override
+    public MessageEmbed setThumbnail(EmbedThumbnail v) {
+        return (MessageEmbed) super.setThumbnail(v);
+    }
+
+    @Override
+    public MessageEmbed setTimestamp(UtcDateTime v) {
+        return (MessageEmbed) super.setTimestamp(v);
+    }
+
+    @Override
+    public MessageEmbed setTitle(String v) {
+        return (MessageEmbed) super.setTitle(v);
+    }
+
+    @Override
+    public MessageEmbed setType(EmbedType v) {
+        return (MessageEmbed) super.setType(v);
+    }
+
+    @Override
+    public MessageEmbed setUrl(String v) {
+        return (MessageEmbed) super.setUrl(v);
+    }
+
+    @Override
+    public MessageEmbed setVideo(EmbedVideo v) {
+        return (MessageEmbed) super.setVideo(v);
+    }
+}

--- a/Aliucord/src/main/java/com/aliucord/entities/MessageEmbedBuilder.java
+++ b/Aliucord/src/main/java/com/aliucord/entities/MessageEmbedBuilder.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 import java.util.List;
 
 @SuppressWarnings("unused")
-public class MessageEmbed {
+public class MessageEmbedBuilder {
     // reflect moment
     private static Field authorField;
     private static Field colorField;
@@ -64,18 +64,22 @@ public class MessageEmbed {
         } catch (Exception e) { Main.logger.error(e); }
     }
 
-    public com.discord.api.message.embed.MessageEmbed embed;
+    private final com.discord.api.message.embed.MessageEmbed embed;
 
-    public MessageEmbed() {
+    public MessageEmbedBuilder() {
         this(EmbedType.RICH);
     }
 
-    public MessageEmbed(EmbedType type) {
+    public MessageEmbedBuilder(EmbedType type) {
         embed = new com.discord.api.message.embed.MessageEmbed();
         setType(type);
     }
 
-    public MessageEmbed setAuthor(String name, String iconUrl, String url) {
+    public MessageEmbed build() {
+        return embed;
+    }
+
+    public MessageEmbedBuilder setAuthor(String name, String iconUrl, String url) {
         EmbedAuthor author = new EmbedAuthor();
         Class<EmbedAuthor> c = EmbedAuthor.class;
         try {
@@ -85,32 +89,32 @@ public class MessageEmbed {
         } catch (Throwable e) { Main.logger.error(e); }
         return setAuthor(author);
     }
-    public MessageEmbed setAuthor(EmbedAuthor v) {
+    public MessageEmbedBuilder setAuthor(EmbedAuthor v) {
         try {
             authorField.set(embed, v);
         } catch (Throwable e) { Main.logger.error(e); }
         return this;
     }
 
-    public MessageEmbed setColor(Integer v) {
+    public MessageEmbedBuilder setColor(Integer v) {
         try {
             colorField.set(embed, v);
         } catch (Throwable e) { Main.logger.error(e); }
         return this;
     }
 
-    public MessageEmbed setDescription(String v) {
+    public MessageEmbedBuilder setDescription(String v) {
         try {
             descriptionField.set(embed, v);
         } catch (Throwable e) { Main.logger.error(e); }
         return this;
     }
 
-    public MessageEmbed addField(String name, String value, boolean inline) {
+    public MessageEmbedBuilder addField(String name, String value, boolean inline) {
         return addField(createField(name, value, inline));
     }
     @SuppressWarnings("unchecked")
-    public MessageEmbed addField(EmbedField v) {
+    public MessageEmbedBuilder addField(EmbedField v) {
         try {
             List<EmbedField> o = (List<EmbedField>) fieldsField.get(embed);
             if (o == null) fieldsField.set(embed, Collections.singletonList(v));
@@ -123,14 +127,14 @@ public class MessageEmbed {
         return this;
     }
 
-    public MessageEmbed setFields(List<EmbedField> v) {
+    public MessageEmbedBuilder setFields(List<EmbedField> v) {
         try {
             fieldsField.set(embed, v);
         } catch (Throwable e) { Main.logger.error(e); }
         return this;
     }
 
-    public MessageEmbed setFooter(String text, String iconUrl) {
+    public MessageEmbedBuilder setFooter(String text, String iconUrl) {
         EmbedFooter footer = new EmbedFooter();
         Class<EmbedFooter> c = EmbedFooter.class;
         try {
@@ -139,63 +143,63 @@ public class MessageEmbed {
         } catch (Throwable e) { Main.logger.error(e); }
         return setFooter(footer);
     }
-    public MessageEmbed setFooter(EmbedFooter v) {
+    public MessageEmbedBuilder setFooter(EmbedFooter v) {
         try {
             footerField.set(embed, v);
         } catch (Throwable e) { Main.logger.error(e); }
         return this;
     }
 
-    public MessageEmbed setImage(EmbedImage v) {
+    public MessageEmbedBuilder setImage(EmbedImage v) {
         try {
             imageField.set(embed, v);
         } catch (Throwable e) { Main.logger.error(e); }
         return this;
     }
 
-    public MessageEmbed setProvider(EmbedProvider v) {
+    public MessageEmbedBuilder setProvider(EmbedProvider v) {
         try {
             providerField.set(embed, v);
         } catch (Throwable e) { Main.logger.error(e); }
         return this;
     }
 
-    public MessageEmbed setThumbnail(EmbedThumbnail v) {
+    public MessageEmbedBuilder setThumbnail(EmbedThumbnail v) {
         try {
             thumbnailField.set(embed, v);
         } catch (Throwable e) { Main.logger.error(e); }
         return this;
     }
 
-    public MessageEmbed setTimestamp(UtcDateTime v) {
+    public MessageEmbedBuilder setTimestamp(UtcDateTime v) {
         try {
             timestampField.set(embed, v);
         } catch (Throwable e) { Main.logger.error(e); }
         return this;
     }
 
-    public MessageEmbed setTitle(String v) {
+    public MessageEmbedBuilder setTitle(String v) {
         try {
             titleField.set(embed, v);
         } catch (Throwable e) { Main.logger.error(e); }
         return this;
     }
 
-    public MessageEmbed setType(EmbedType v) {
+    public MessageEmbedBuilder setType(EmbedType v) {
         try {
             typeField.set(embed, v);
         } catch (Throwable e) { Main.logger.error(e); }
         return this;
     }
 
-    public MessageEmbed setUrl(String v) {
+    public MessageEmbedBuilder setUrl(String v) {
         try {
             urlField.set(embed, v);
         } catch (Throwable e) { Main.logger.error(e); }
         return this;
     }
 
-    public MessageEmbed setVideo(EmbedVideo v) {
+    public MessageEmbedBuilder setVideo(EmbedVideo v) {
         try {
             videoField.set(embed, v);
         } catch (Throwable e) { Main.logger.error(e); }

--- a/Aliucord/src/main/java/com/aliucord/entities/MessageEmbedBuilder.java
+++ b/Aliucord/src/main/java/com/aliucord/entities/MessageEmbedBuilder.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "deprecation"})
 public class MessageEmbedBuilder {
     // reflect moment
     private static Field authorField;
@@ -64,7 +64,10 @@ public class MessageEmbedBuilder {
         } catch (Exception e) { Main.logger.error(e); }
     }
 
-    private final com.discord.api.message.embed.MessageEmbed embed;
+    // NOTE: make it private again after
+    /** @deprecated Use build() instead */
+    @Deprecated
+    public final com.discord.api.message.embed.MessageEmbed embed;
 
     public MessageEmbedBuilder() {
         this(EmbedType.RICH);
@@ -75,7 +78,7 @@ public class MessageEmbedBuilder {
         setType(type);
     }
 
-    public MessageEmbed build() {
+    public com.discord.api.message.embed.MessageEmbed build() {
         return embed;
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:4.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.1'
@@ -15,7 +15,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jan 02 22:26:39 CET 2021
+#Wed Jun 02 20:07:31 GET 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/installer/android/app/build.gradle
+++ b/installer/android/app/build.gradle
@@ -41,7 +41,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "com.aliucord.installer"

--- a/installer/android/build.gradle
+++ b/installer/android/build.gradle
@@ -1,18 +1,18 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'com.android.tools.build:gradle:4.2.1'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
# Summary
Plugin developers can now customize Clyde's name and avatar, making it more user friendly and unique per plugin.

## Usage
`CommandsAPI.CommandResult` got 2 new parameters in the constructor, those are `username` and `avatarUrl`. `username` is used for the bot name and `avatarUrl` is the URL used for bot's avatar. Note: URL set in `avatarUrl` must point to raw image and not a redirect.

## Example
```java
MessageEmbed embed = new MessageEmbedBuilder()
        .setTitle("Drac")
        .setDescription("Haha Jonathan, you are banging my daughter.")
        .build();

return new CommandsAPI.CommandResult(null, embed, "Drac", "https://i.kym-cdn.com/entries/icons/original/000/037/312/cover2.jpg", false)
```

# Breaking Changes
MessageEmbed has been renamed to MessageEmbedBuilder and the `embed` field is now private, instead plugin developers should use the `build()` method which returns the Discord's `MessageEmbed`.

# Other Info
Also updated build script including `targetSdk`, `compileSdk` and `buildToolVersion`. Installer still targets sdk 29 because of scoped storage enforcements when targeting API 30.