### PR TITLE
Add RxUtils.getResultBlocking

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/utils/RxUtils.java
+++ b/Aliucord/src/main/java/com/aliucord/utils/RxUtils.java
@@ -61,7 +61,11 @@ public class RxUtils {
             }
         }
 
-        return new Pair<>((T) result[0], (Throwable) result[1]);
+        T res;
+        try {
+            res = (T) result[0];
+        } catch (Throwable ignored) { res = null; }
+        return new Pair<>(res, (Throwable) result[1]);
     }
 
     /**


### PR DESCRIPTION
Example usage:

```java
var api = RestAPI.getApi();
var obs = api.getChannelMessagesAround(811261478875299840L, 5, 854461004657721365L);
var result = RxUtils.getResultBlocking(obs);
if (result.second != null) {
    Log.e("Oh no", "Horrible Error", result.second);
    return null;
} else {
    return new CommandsAPI.CommandResult("Wow it worked!!", null, false);
}
```