### PR TITLE
add InputDialog fragment & improve ConfirmDialog

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/fragments/ConfirmDialog.java
+++ b/Aliucord/src/main/java/com/aliucord/fragments/ConfirmDialog.java
@@ -17,7 +17,7 @@ import com.discord.widgets.guilds.leave.WidgetLeaveGuildDialog$binding$2;
 import com.google.android.material.button.MaterialButton;
 
 /**
- * Creates a Confirmation Dialog similar to the <bold>Leave Guild</bold> dialog.
+ * Creates a Confirmation Dialog similar to the <strong>Leave Guild</strong> dialog.
  * This class offers convenient builder methods so you should usually not have to do any layouts manually.
  */
 @SuppressWarnings("unused")

--- a/Aliucord/src/main/java/com/aliucord/fragments/ConfirmDialog.java
+++ b/Aliucord/src/main/java/com/aliucord/fragments/ConfirmDialog.java
@@ -6,6 +6,7 @@
 package com.aliucord.fragments;
 
 import android.view.View;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.aliucord.Utils;
@@ -15,6 +16,10 @@ import com.discord.views.LoadingButton;
 import com.discord.widgets.guilds.leave.WidgetLeaveGuildDialog$binding$2;
 import com.google.android.material.button.MaterialButton;
 
+/**
+ * Creates a Confirmation Dialog similar to the <bold>Leave Guild</bold> dialog.
+ * This class offers convenient builder methods so you should usually not have to do any layouts manually.
+ */
 @SuppressWarnings("unused")
 public class ConfirmDialog extends AppDialog {
     public ConfirmDialog() {
@@ -22,6 +27,10 @@ public class ConfirmDialog extends AppDialog {
     }
 
     private LeaveGuildDialogBinding binding;
+    private CharSequence title;
+    private CharSequence description;
+    private View.OnClickListener onCancelListener;
+    private View.OnClickListener onOkListener;
 
     @Override
     public void onViewBound(View view) {
@@ -31,11 +40,86 @@ public class ConfirmDialog extends AppDialog {
         LoadingButton okButton = getOKButton();
         okButton.setText("OK");
         okButton.setIsLoading(false);
-        okButton.setOnClickListener(e -> dismiss());
+        okButton.setOnClickListener(onOkListener != null ? onOkListener : e -> dismiss());
+
+        if (title != null) getHeader().setText(title);
+        if (description != null) getBody().setText(description);
+        if (onCancelListener != null) getCancelButton().setOnClickListener(onCancelListener);
+
     }
 
+    /**
+     * Returns the root layout of this dialog.
+     * Should only be called from within onClickHandlers or onViewBound as it will likely throw a {@link NullPointerException} in other cases
+     */
+    public final LinearLayout getRoot() { return binding.a; }
+
+    /**
+     * Returns the cancel button of this dialog.
+     * Should only be called from within onClickHandlers or onViewBound as it will likely throw a {@link NullPointerException} in other cases
+     * @see #setOnOkListener(View.OnClickListener)
+     */
     public final MaterialButton getCancelButton() { return binding.b; }
+
+    /**
+     * Returns the OK button of this dialog.
+     * Should only be called from within onClickHandlers or onViewBound as it will likely throw a {@link NullPointerException} in other cases
+     * @see #setOnOkListener(View.OnClickListener)
+     */
     public final LoadingButton getOKButton() { return binding.c; }
+
+    /**
+     * Returns the body of this dialog.
+     * Should only be called from within onClickHandlers or onViewBound as it will likely throw a {@link NullPointerException} in other cases
+     * @see #setDescription(CharSequence)
+     */
     public final TextView getBody() { return binding.d; }
+
+    /**
+     * Returns the header of this dialog.
+     * Should only be called from within onClickHandlers or onViewBound as it will likely throw a {@link NullPointerException} in other cases
+     * @see #setTitle(CharSequence)
+     */
     public final TextView getHeader() { return binding.e; }
+
+
+    /**
+     * Sets the title of this dialog
+     * @param title The description
+     * @return Builder for chaining
+     */
+    public ConfirmDialog setTitle(CharSequence title) {
+        this.title = title;
+        return this;
+    }
+
+    /**
+     * Sets the description of this dialog
+     * @param description The description
+     * @return Builder for chaining
+     */
+    public ConfirmDialog setDescription(CharSequence description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Sets the {@link View.OnClickListener} that will be called when the OK button is pressed (By default simply closes this dialog)
+     * @param listener The listener
+     * @return Builder for chaining
+     */
+    public ConfirmDialog setOnOkListener(View.OnClickListener listener) {
+        onOkListener = listener;
+        return this;
+    }
+
+    /**
+     * Sets the {@link View.OnClickListener} that will be called when the cancel button is pressed (By default simply closes this dialog)
+     * @param listener The listener
+     * @return Builder for chaining
+     */
+    public ConfirmDialog setOnCancelListener(View.OnClickListener listener) {
+        onCancelListener = listener;
+        return this;
+    }
 }

--- a/Aliucord/src/main/java/com/aliucord/fragments/ConfirmDialog.java
+++ b/Aliucord/src/main/java/com/aliucord/fragments/ConfirmDialog.java
@@ -42,10 +42,9 @@ public class ConfirmDialog extends AppDialog {
         okButton.setIsLoading(false);
         okButton.setOnClickListener(onOkListener != null ? onOkListener : e -> dismiss());
 
-        if (title != null) getHeader().setText(title);
-        if (description != null) getBody().setText(description);
-        if (onCancelListener != null) getCancelButton().setOnClickListener(onCancelListener);
-
+        getCancelButton().setOnClickListener(onCancelListener != null ? onCancelListener : e -> dismiss());
+        getHeader().setText(title != null ? title : "Confirm");
+        getBody().setText(description != null ? description : "Are you sure?");
     }
 
     /**

--- a/Aliucord/src/main/java/com/aliucord/fragments/InputDialog.java
+++ b/Aliucord/src/main/java/com/aliucord/fragments/InputDialog.java
@@ -13,7 +13,7 @@ import com.discord.utilities.color.ColorCompat;
 import com.discord.widgets.user.WidgetKickUser$binding$2;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.textfield.TextInputLayout;
-import com.lytefast.flexinput.R$c;
+import com.lytefast.flexinput.R$b;
 
 import java.util.Objects;
 
@@ -56,7 +56,10 @@ public class InputDialog extends AppDialog {
         if (inputType != null && inputLayout.getEditText() != null) inputLayout.getEditText().setInputType(inputType);
 
         MaterialButton okButton = getOKButton();
-        okButton.setBackgroundColor(ColorCompat.getThemedColor(view, R$c.brand));
+        LinearLayout buttonLayout = ((LinearLayout) okButton.getParent());
+        // The button has no room to breathe - Discord moment, it doesn't even line up with the input field ~ Whatever, fix that
+        buttonLayout.setPadding(buttonLayout.getPaddingLeft(), buttonLayout.getPaddingTop(), buttonLayout.getPaddingRight() * 2, buttonLayout.getPaddingBottom());
+        okButton.setBackgroundColor(ColorCompat.getThemedColor(view, R$b.colorButtonNormal));
         okButton.setOnClickListener(onOkListener != null ? onOkListener : e -> dismiss());
 
         getCancelButton().setOnClickListener(onCancelListener != null ? onCancelListener : e -> dismiss());

--- a/Aliucord/src/main/java/com/aliucord/fragments/InputDialog.java
+++ b/Aliucord/src/main/java/com/aliucord/fragments/InputDialog.java
@@ -14,11 +14,10 @@ import android.widget.*;
 import com.aliucord.Utils;
 import com.discord.app.AppDialog;
 import com.discord.databinding.WidgetKickUserBinding;
-import com.discord.utilities.color.ColorCompat;
 import com.discord.widgets.user.WidgetKickUser$binding$2;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.textfield.TextInputLayout;
-import com.lytefast.flexinput.R$b;
+import com.lytefast.flexinput.R$c;
 
 import java.util.Objects;
 
@@ -64,7 +63,7 @@ public class InputDialog extends AppDialog {
         LinearLayout buttonLayout = ((LinearLayout) okButton.getParent());
         // The button has no room to breathe - Discord moment, it doesn't even line up with the input field ~ Whatever, fix that
         buttonLayout.setPadding(buttonLayout.getPaddingLeft(), buttonLayout.getPaddingTop(), buttonLayout.getPaddingRight() * 2, buttonLayout.getPaddingBottom());
-        okButton.setBackgroundColor(ColorCompat.getThemedColor(view, R$b.colorButtonNormal));
+        okButton.setBackgroundColor(view.getResources().getColor(R$c.uikit_btn_bg_color_selector_brand, view.getContext().getTheme()));
         okButton.setOnClickListener(onOkListener != null ? onOkListener : e -> dismiss());
 
         getCancelButton().setOnClickListener(onCancelListener != null ? onCancelListener : e -> dismiss());

--- a/Aliucord/src/main/java/com/aliucord/fragments/InputDialog.java
+++ b/Aliucord/src/main/java/com/aliucord/fragments/InputDialog.java
@@ -1,0 +1,173 @@
+package com.aliucord.fragments;
+
+import static android.view.View.OnClickListener;
+
+import android.annotation.SuppressLint;
+import android.view.View;
+import android.widget.*;
+
+import com.aliucord.Utils;
+import com.discord.app.AppDialog;
+import com.discord.databinding.WidgetKickUserBinding;
+import com.discord.utilities.color.ColorCompat;
+import com.discord.widgets.user.WidgetKickUser$binding$2;
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.textfield.TextInputLayout;
+import com.lytefast.flexinput.R$c;
+
+import java.util.Objects;
+
+/**
+ * Creates a Input Dialog similar to the <bold>Kick User</bold> dialog.
+ * This class offers convenient builder methods so you should usually not have to do any layouts manually.
+ */
+@SuppressWarnings("unused")
+public class InputDialog extends AppDialog {
+    public InputDialog() {
+        super(Utils.getResId("widget_kick_user", "layout"));
+    }
+
+    private WidgetKickUserBinding binding;
+    private CharSequence title;
+    private CharSequence description;
+    private CharSequence placeholder;
+    private View.OnClickListener onCancelListener;
+    private View.OnClickListener onOkListener;
+    private Integer inputType;
+
+    @SuppressLint("SetTextI18n")
+    @Override
+    public void onViewBound(View view) {
+        super.onViewBound(view);
+
+        binding = WidgetKickUser$binding$2.INSTANCE.invoke(view);
+
+        // Hide ugly redundant secondary "REASON FOR KICK" header
+        ((LinearLayout) ((ScrollView) ((LinearLayout) view).getChildAt(2)).getChildAt(0)).getChildAt(1).setVisibility(View.GONE);
+
+        if (title != null) getHeader().setText(title);
+        if (description != null) getBody().setText(description);
+
+        TextInputLayout inputLayout = getInputLayout();
+        if (placeholder != null) inputLayout.setHint(placeholder);
+        else if (title != null) inputLayout.setHint(title);
+        else inputLayout.setHint("Text");
+
+        if (inputType != null && inputLayout.getEditText() != null) inputLayout.getEditText().setInputType(inputType);
+
+        MaterialButton okButton = getOKButton();
+        okButton.setBackgroundColor(ColorCompat.getThemedColor(view, R$c.brand));
+        okButton.setOnClickListener(onOkListener != null ? onOkListener : e -> dismiss());
+
+        getCancelButton().setOnClickListener(onCancelListener != null ? onCancelListener : e -> dismiss());
+    }
+
+    /**
+     * Returns the root layout of this dialog.
+     * Should only be called from within onClickHandlers or onViewBound as it will likely throw a {@link NullPointerException} in other cases
+     */
+    public final LinearLayout getRoot() { return binding.a; }
+
+    /**
+     * Returns the cancel {@link MaterialButton} of this dialog.
+     * Should only be called from within onClickHandlers or onViewBound as it will likely throw a {@link NullPointerException} in other cases
+     * @see #setOnCancelListener(OnClickListener)
+     */
+    public final MaterialButton getCancelButton() { return binding.c; }
+
+    /**
+     * Returns the OK {@link MaterialButton} of this dialog.
+     * Should only be called from within onClickHandlers or onViewBound as it will likely throw a {@link NullPointerException} in other cases
+     * @see #setOnOkListener(OnClickListener)
+     */
+    public final MaterialButton getOKButton() { return binding.d; }
+
+    /**
+     * Returns the body of this dialog.
+     * Should only be called from within onClickHandlers or onViewBound as it will likely throw a {@link NullPointerException} in other cases
+     * @see #setDescription(CharSequence)
+     */
+    public final TextView getBody() { return binding.b; }
+
+    /**
+     * Returns the header of this dialog.
+     * Should only be called from within onClickHandlers or onViewBound as it will likely throw a {@link NullPointerException} in other cases
+     * @see #setTitle(CharSequence)
+     */
+    public final TextView getHeader() { return binding.f; }
+
+    /**
+     * Returns the {@link TextInputLayout} of this dialog.
+     * Should only be called from within onClickHandlers or onViewBound as it will likely throw a {@link NullPointerException} in other cases
+     * @see #setInputType(int)
+     * @see #getInput()
+     */
+    public final TextInputLayout getInputLayout() { return binding.e; }
+
+    /**
+     * Returns the input the user entered.
+     * Should only be called from within onClickHandlers or onViewBound as it will likely throw a {@link NullPointerException} in other cases
+     * @see #getInputLayout()
+     */
+    public String getInput() { return Objects.requireNonNull(getInputLayout().getEditText()).getText().toString(); }
+
+    /**
+     * Sets the title of this dialog
+     * @param title The description
+     * @return Builder for chaining
+     */
+    public InputDialog setTitle(CharSequence title) {
+        this.title = title;
+        return this;
+    }
+
+    /**
+     * Sets the description of this dialog
+     * @param description The description
+     * @return Builder for chaining
+     */
+    public InputDialog setDescription(CharSequence description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Sets the placeholder text for the input field (By default the title if set or "Text")
+     * @param placeholder The placeholder text
+     * @return Builder for chaining
+     */
+    public InputDialog setPlaceholderText(CharSequence placeholder) {
+        this.placeholder = placeholder;
+        return this;
+    }
+
+    /**
+     * Sets the {@link OnClickListener} that will be called when the OK button is pressed (By default simply closes this dialog)
+     * @param listener The listener
+     * @return Builder for chaining
+     */
+    public InputDialog setOnOkListener(OnClickListener listener) {
+        onOkListener = listener;
+        return this;
+    }
+
+    /**
+     * Sets the {@link OnClickListener} that will be called when the cancel button is pressed (By default simply closes this dialog)
+     * @param listener The listener
+     * @return Builder for chaining
+     */
+    public InputDialog setOnCancelListener(OnClickListener listener) {
+        onCancelListener = listener;
+        return this;
+    }
+
+    /**
+     * Sets the {@link android.text.InputType}
+     * @param type The input type
+     * @return Builder for chaining
+     */
+    public InputDialog setInputType(int type) {
+        inputType = type;
+        return this;
+    };
+}

--- a/Aliucord/src/main/java/com/aliucord/fragments/InputDialog.java
+++ b/Aliucord/src/main/java/com/aliucord/fragments/InputDialog.java
@@ -18,7 +18,7 @@ import com.lytefast.flexinput.R$b;
 import java.util.Objects;
 
 /**
- * Creates a Input Dialog similar to the <bold>Kick User</bold> dialog.
+ * Creates a Input Dialog similar to the <strong>Kick User</strong> dialog.
  * This class offers convenient builder methods so you should usually not have to do any layouts manually.
  */
 @SuppressWarnings("unused")

--- a/Aliucord/src/main/java/com/aliucord/fragments/InputDialog.java
+++ b/Aliucord/src/main/java/com/aliucord/fragments/InputDialog.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
 package com.aliucord.fragments;
 
 import static android.view.View.OnClickListener;

--- a/Aliucord/src/main/java/com/aliucord/fragments/InputDialog.java
+++ b/Aliucord/src/main/java/com/aliucord/fragments/InputDialog.java
@@ -45,8 +45,8 @@ public class InputDialog extends AppDialog {
         // Hide ugly redundant secondary "REASON FOR KICK" header
         ((LinearLayout) ((ScrollView) ((LinearLayout) view).getChildAt(2)).getChildAt(0)).getChildAt(1).setVisibility(View.GONE);
 
-        if (title != null) getHeader().setText(title);
-        if (description != null) getBody().setText(description);
+        getHeader().setText(title != null ? title : "Input");
+        getBody().setText(description != null ? description : "Please enter some text");
 
         TextInputLayout inputLayout = getInputLayout();
         if (placeholder != null) inputLayout.setHint(placeholder);

--- a/DiscordStubs/src/main/java/com/discord/databinding/WidgetKickUserBinding.java
+++ b/DiscordStubs/src/main/java/com/discord/databinding/WidgetKickUserBinding.java
@@ -1,0 +1,55 @@
+package com.discord.databinding;
+
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.viewbinding.ViewBinding;
+
+import com.google.android.material.button.MaterialButton;
+import com.google.android.material.textfield.TextInputLayout;
+
+public class WidgetKickUserBinding implements ViewBinding {
+    /** root */
+    @NonNull
+    public final LinearLayout a;
+    /** body */
+    @NonNull
+    public final TextView b;
+
+    /** cancel */
+    @NonNull
+    public final MaterialButton c;
+    /** kick */
+    @NonNull
+    public final MaterialButton d;
+
+    /** reason */
+    @NonNull
+    public final TextInputLayout e;
+    /** title */
+    @NonNull
+    public final TextView f;
+
+    public WidgetKickUserBinding(
+            @NonNull LinearLayout linearLayout,
+            @NonNull TextView textView,
+            @NonNull MaterialButton materialButton,
+            @NonNull MaterialButton materialButton2,
+            @NonNull TextInputLayout textInputLayout,
+            @NonNull TextView textView2) {
+        a = linearLayout;
+        b = textView;
+        c = materialButton;
+        d = materialButton2;
+        e = textInputLayout;
+        f = textView2;
+    }
+
+    @Override
+    @NonNull
+    public View getRoot() {
+        return a;
+    }
+}

--- a/DiscordStubs/src/main/java/com/discord/views/RadioManager.java
+++ b/DiscordStubs/src/main/java/com/discord/views/RadioManager.java
@@ -10,6 +10,8 @@ public class RadioManager {
 
     public RadioManager(List<? extends Checkable> buttons) {}
 
+    /** setActiveCheckable */
     public void a(Checkable checkable) {}
+    /** getSelectedIndex */
     public int b() { return 0; }
 }

--- a/DiscordStubs/src/main/java/com/discord/widgets/guilds/leave/WidgetLeaveGuildDialog$binding$2.java
+++ b/DiscordStubs/src/main/java/com/discord/widgets/guilds/leave/WidgetLeaveGuildDialog$binding$2.java
@@ -9,5 +9,5 @@ import kotlin.jvm.functions.Function1;
 public final class WidgetLeaveGuildDialog$binding$2 implements Function1<View, LeaveGuildDialogBinding> {
     public static final WidgetLeaveGuildDialog$binding$2 INSTANCE = new WidgetLeaveGuildDialog$binding$2();
 
-    public final LeaveGuildDialogBinding invoke(View view) { return null; }
+    public final LeaveGuildDialogBinding invoke(View view) { return invoke(view); }
 }

--- a/DiscordStubs/src/main/java/com/discord/widgets/user/WidgetKickUser$binding$2.java
+++ b/DiscordStubs/src/main/java/com/discord/widgets/user/WidgetKickUser$binding$2.java
@@ -1,0 +1,13 @@
+package com.discord.widgets.user;
+
+import android.view.View;
+
+import com.discord.databinding.WidgetKickUserBinding;
+
+import kotlin.jvm.functions.Function1;
+
+public class WidgetKickUser$binding$2 implements Function1<View, WidgetKickUserBinding> {
+    public static final WidgetKickUser$binding$2 INSTANCE = new WidgetKickUser$binding$2();
+
+    public final WidgetKickUserBinding invoke(View view) { return invoke(view); }
+}

--- a/DiscordStubs/src/main/java/com/lytefast/flexinput/R$c.java
+++ b/DiscordStubs/src/main/java/com/lytefast/flexinput/R$c.java
@@ -3,6 +3,7 @@ package com.lytefast.flexinput;
 @SuppressWarnings("unused")
 public class R$c {
     public static int brand = 0;
+    public static int brand_new_500 = 0;
     public static int hypesquad_house_1 = 0;
     public static int hypesquad_house_2 = 0;
     public static int hypesquad_house_3 = 0;


### PR DESCRIPTION
Example usage:
```java
var dialog = new InputDialog()
        .setPlaceholderText("Filename")
        .setTitle("Filename")
        .setDescription("Please specify a name for this theme");
dialog.setOnOkListener(e -> {
        var text = dialog.getInput();
        if (text.length() > 0) {
            try {
                importTheme(contentUri, text);
            } catch (Throwable ex) {
                Themer.logger.error(requireContext(), "Failed to import theme.", ex);
            }
            dialog.dismiss();
        }
});
dialog.show(getParentFragmentManager(), "Themer");
```
Result:
![Screenshot](https://cdn.discordapp.com/attachments/811263527239024640/865769907899990046/Screenshot_20210717-034015.jpg)