### PR TITLE
Errors Not Showing Multiple Authors

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
+++ b/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
@@ -260,9 +260,10 @@ public class CommandsAPI {
                             Locale.ENGLISH,
                             "Oops! Something went wrong while running this command:\n```java\n%s```\n" +
                             "Please search for this error on the Aliucord server to see if it's a known issue. " +
-                            "If it isn't, report it to the plugin author%s.\n\n" +
+                            "If it isn't, report it to the plugin %s%s.\n\n" +
                             "Debug:```\nCommand: %s\nPlugin: %s v%s\nDiscord v%s\nAndroid %s (SDK %d)\nAliucord %s```\nArguments:```\n%s```\n",
                             t.toString(),
+                            Utils.pluralise(manifest.authors.length, ("author")),
                             manifest.authors.length != 0 ? " (" + TextUtils.join(", ", manifest.authors) + ")" : "",
                             name,
                             pluginName,

--- a/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
+++ b/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
@@ -9,6 +9,7 @@ import android.os.Build;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import android.text.TextUtils;
 
 import com.aliucord.*;
 import com.aliucord.entities.CommandContext;

--- a/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
+++ b/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
@@ -6,10 +6,10 @@
 package com.aliucord.api;
 
 import android.os.Build;
+import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import android.text.TextUtils;
 
 import com.aliucord.*;
 import com.aliucord.entities.CommandContext;

--- a/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
+++ b/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
@@ -262,7 +262,7 @@ public class CommandsAPI {
                             "If it isn't, report it to the plugin author%s.\n\n" +
                             "Debug:```\nCommand: %s\nPlugin: %s v%s\nDiscord v%s\nAndroid %s (SDK %d)\nAliucord %s```\nArguments:```\n%s```\n",
                             t.toString(),
-                            manifest.authors.length != 0 ? " (" + manifest.authors[0].name + ")" : "",
+                            manifest.authors.length != 0 ? " (" + manifest.authors.join(", ") + ")" : "",
                             name,
                             pluginName,
                             manifest.version,

--- a/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
+++ b/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
@@ -262,7 +262,7 @@ public class CommandsAPI {
                             "If it isn't, report it to the plugin author%s.\n\n" +
                             "Debug:```\nCommand: %s\nPlugin: %s v%s\nDiscord v%s\nAndroid %s (SDK %d)\nAliucord %s```\nArguments:```\n%s```\n",
                             t.toString(),
-                            manifest.authors.length != 0 ? " (" + manifest.authors.join(", ") + ")" : "",
+                            manifest.authors.length != 0 ? " (" + TextUtils.join(", ", manifest.authors) + ")" : "",
                             name,
                             pluginName,
                             manifest.version,

--- a/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
+++ b/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
@@ -260,10 +260,10 @@ public class CommandsAPI {
                             Locale.ENGLISH,
                             "Oops! Something went wrong while running this command:\n```java\n%s```\n" +
                             "Please search for this error on the Aliucord server to see if it's a known issue. " +
-                            "If it isn't, report it to the plugin %s%s.\n\n" +
+                            "If it isn't, report it to the plugin author%s%s.\n\n" +
                             "Debug:```\nCommand: %s\nPlugin: %s v%s\nDiscord v%s\nAndroid %s (SDK %d)\nAliucord %s```\nArguments:```\n%s```\n",
                             t.toString(),
-                            Utils.pluralise(manifest.authors.length, ("author")),
+                            manifest.authors.length == 1 ? "" : "s",
                             manifest.authors.length != 0 ? " (" + TextUtils.join(", ", manifest.authors) + ")" : "",
                             name,
                             pluginName,

--- a/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
+++ b/Aliucord/src/main/java/com/aliucord/api/CommandsAPI.java
@@ -260,10 +260,10 @@ public class CommandsAPI {
                             Locale.ENGLISH,
                             "Oops! Something went wrong while running this command:\n```java\n%s```\n" +
                             "Please search for this error on the Aliucord server to see if it's a known issue. " +
-                            "If it isn't, report it to the plugin author%s%s.\n\n" +
+                            "If it isn't, report it to the plugin %s%s.\n\n" +
                             "Debug:```\nCommand: %s\nPlugin: %s v%s\nDiscord v%s\nAndroid %s (SDK %d)\nAliucord %s```\nArguments:```\n%s```\n",
                             t.toString(),
-                            manifest.authors.length == 1 ? "" : "s",
+                            manifest.authors.length == 1 ? "author" : "authors",
                             manifest.authors.length != 0 ? " (" + TextUtils.join(", ", manifest.authors) + ")" : "",
                             name,
                             pluginName,


### PR DESCRIPTION
Currently when a error is made by a plugin it will show the author but if a plugin has multiple authors it will only show the first author and not the other authors