### PR TITLE
Add links to the manifest

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/PluginManager.java
+++ b/Aliucord/src/main/java/com/aliucord/PluginManager.java
@@ -11,6 +11,8 @@ import android.content.res.AssetManager;
 import android.content.res.Resources;
 
 import com.aliucord.entities.Plugin;
+import com.aliucord.patcher.Patcher;
+import com.aliucord.patcher.PineInsteadFn;
 import com.aliucord.utils.*;
 
 import java.io.*;
@@ -71,6 +73,8 @@ public class PluginManager {
 
                 manifest.name = pluginInstance.name;
                 pluginInstance.initialize(manifest);
+
+                Patcher.addPatch(pluginClass.getDeclaredMethod("getManifest"), new PineInsteadFn(callFrame -> manifest));
             } else {
                 logger.error(context, "No manifest found for plugin: " + fileName, null);
                 return;

--- a/Aliucord/src/main/java/com/aliucord/entities/Plugin.java
+++ b/Aliucord/src/main/java/com/aliucord/entities/Plugin.java
@@ -161,7 +161,7 @@ public abstract class Plugin {
 
         this.manifest = manifest;
 
-        if (manifest.links.getSource() == null) {
+        if (manifest.updateUrl != null && manifest.links.getSource() == null) {
             var matcher = MONO_REPO_UPDATER_PATTERN.matcher(manifest.updateUrl);
             if (matcher.matches()) {
                 manifest.links.put(Manifest.Links.GITHUB, "https://github.com/" + matcher.group(1));

--- a/Aliucord/src/main/java/com/aliucord/settings/Plugins.java
+++ b/Aliucord/src/main/java/com/aliucord/settings/Plugins.java
@@ -54,15 +54,15 @@ public class Plugins extends SettingsPage {
                 this.adapter = adapter;
                 this.card = card;
 
-                card.repoButton.setOnClickListener(this::onGithubClick);
+                card.repoButton.setOnClickListener(this::onRepoClick);
                 card.changeLogButton.setOnClickListener(this::onChangeLogClick);
                 card.uninstallButton.setOnClickListener(this::onUninstallClick);
                 card.switchHeader.setOnCheckedListener(this::onToggleClick);
                 card.settingsButton.setOnClickListener(this::onSettingsClick);
             }
 
-            public void onGithubClick(View view) {
-                adapter.onGithubClick(getAdapterPosition());
+            public void onRepoClick(View view) {
+                adapter.onRepoClick(getAdapterPosition());
             }
 
             public void onChangeLogClick(View view) {
@@ -125,6 +125,7 @@ public class Plugins extends SettingsPage {
             holder.card.settingsButton.setVisibility(p.settingsTab != null ? View.VISIBLE : View.GONE);
             holder.card.settingsButton.setEnabled(enabled);
             holder.card.changeLogButton.setVisibility(p.getManifest().changelog != null ? View.VISIBLE : View.GONE);
+            holder.card.repoButton.setVisibility(p.getManifest().links.getSource() != null ? View.VISIBLE : View.GONE);
 
             String title = String.format("%s v%s by %s", p.getName(), manifest.version, TextUtils.join(", ", manifest.authors));
             SpannableString spannableTitle = new SpannableString(title);
@@ -198,25 +199,23 @@ public class Plugins extends SettingsPage {
             return filter;
         }
 
-        private String getGithubUrl(Plugin plugin) {
-            return plugin
-                    .getManifest().updateUrl
-                    .replace("raw.githubusercontent.com", "github.com")
-                    .replaceFirst("/builds.*", "");
-        }
-
-        public void onGithubClick(int position) {
-            Utils.launchUrl(getGithubUrl(data.get(position)));
+        public void onRepoClick(int position) {
+            var repoUrl = data.get(position).getManifest().links.getSource();
+            Utils.launchUrl(repoUrl);
         }
 
         public void onChangeLogClick(int position) {
             Plugin p = data.get(position);
             Plugin.Manifest manifest = p.getManifest();
             if (manifest.changelog != null) {
-                String url = getGithubUrl(p);
-                ChangelogUtils.show(ctx, p.getName() + " v" + manifest.version, manifest.changelogMedia, manifest.changelog, new ChangelogUtils.FooterAction(com.lytefast.flexinput.R.d.ic_github_white, url));
+                var repoUrl = p.getManifest().links.getSource();
+                var footerActions = repoUrl != null
+                        ? new ChangelogUtils.FooterAction[]{new ChangelogUtils.FooterAction(com.lytefast.flexinput.R.d.ic_github_white, repoUrl)}
+                        : new ChangelogUtils.FooterAction[0];
+
+                ChangelogUtils.show(ctx, p.getName() + " v" + manifest.version, manifest.changelogMedia, manifest.changelog, footerActions);
             }
-        }   
+        }
 
         public void onSettingsClick(int position) throws Throwable {
             Plugin p = data.get(position);


### PR DESCRIPTION
Adds a new field to the manifest.json, which looks like
```json
"links": {
	"github": "https://github.com/js6pak/WhoReacted"
}
```

It can have any key that you want, which can later be used by aliucord or other plugins.
Aliucord currently only uses `source` (link to a code source, like github or gitlab) and `github` which is a superset of `source`, which behaves the same way but has github icon (which is not implemented because there is no git icon in lytefast lol). They are used in plugin list and changelog footer.
Links could also be used for twitter or whatever

Now that I'm writing this, I don't think that `links` is a good name, maybe something like `metadata` would be more fitting?