### PR TITLE
feat: sort plugins before loading/starting

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/Main.java
+++ b/Aliucord/src/main/java/com/aliucord/Main.java
@@ -52,7 +52,6 @@ import java.io.*;
 import java.lang.reflect.Field;
 import java.sql.Timestamp;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import dalvik.system.PathClassLoader;
 
@@ -311,7 +310,8 @@ public final class Main {
             }
         }
 
-        List<File> sortedPlugins = Arrays.stream(dir.listFiles()).sorted(Comparator.comparing(File::getName)).collect(Collectors.toList());
+        File[] sortedPlugins = dir.listFiles();
+        Arrays.sort(sortedPlugins, Comparator.comparing(File::getName));
 
         for (File f : sortedPlugins) {
             var name = f.getName();
@@ -339,9 +339,10 @@ public final class Main {
     }
 
     private static void startAllPlugins() {
-        List<String> sortedPlugins = PluginManager.plugins.keySet().stream().sorted().collect(Collectors.toList());
+        List<String> plugins = new ArrayList<>(PluginManager.plugins.keySet());
+        Collections.sort(plugins);
 
-        for (String name : sortedPlugins) {
+        for (String name : plugins) {
             try {
                 if (PluginManager.isPluginEnabled(name))
                     PluginManager.startPlugin(name);

--- a/Aliucord/src/main/java/com/aliucord/Main.java
+++ b/Aliucord/src/main/java/com/aliucord/Main.java
@@ -52,6 +52,7 @@ import java.io.*;
 import java.lang.reflect.Field;
 import java.sql.Timestamp;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import dalvik.system.PathClassLoader;
 
@@ -310,7 +311,9 @@ public final class Main {
             }
         }
 
-        for (File f : dir.listFiles()) {
+        List<File> sortedPlugins = Arrays.stream(dir.listFiles()).sorted(Comparator.comparing(File::getName)).collect(Collectors.toList());
+
+        for (File f : sortedPlugins) {
             var name = f.getName();
             if (name.endsWith(".zip")) {
                 PluginManager.loadPlugin(context, f);
@@ -329,14 +332,16 @@ public final class Main {
     @SuppressWarnings("ResultOfMethodCallIgnored")
     private static void rmrf(File file) {
         if (file.isDirectory()) {
-            for (var child: file.listFiles())
+            for (var child : file.listFiles())
                 rmrf(child);
         }
         file.delete();
     }
 
     private static void startAllPlugins() {
-        for (String name : PluginManager.plugins.keySet()) {
+        List<String> sortedPlugins = PluginManager.plugins.keySet().stream().sorted().collect(Collectors.toList());
+
+        for (String name : sortedPlugins) {
             try {
                 if (PluginManager.isPluginEnabled(name))
                     PluginManager.startPlugin(name);

--- a/Aliucord/src/main/java/com/aliucord/Main.java
+++ b/Aliucord/src/main/java/com/aliucord/Main.java
@@ -339,10 +339,7 @@ public final class Main {
     }
 
     private static void startAllPlugins() {
-        List<String> plugins = new ArrayList<>(PluginManager.plugins.keySet());
-        Collections.sort(plugins);
-
-        for (String name : plugins) {
+        for (String name : PluginManager.plugins.keySet()) {
             try {
                 if (PluginManager.isPluginEnabled(name))
                     PluginManager.startPlugin(name);

--- a/Aliucord/src/main/java/com/aliucord/PluginManager.java
+++ b/Aliucord/src/main/java/com/aliucord/PluginManager.java
@@ -22,7 +22,7 @@ import dalvik.system.PathClassLoader;
 /** Aliucord's Plugin Manager */
 public class PluginManager {
     /** Map containing all loaded plugins */
-    public static final Map<String, Plugin> plugins = new HashMap<>();
+    public static final Map<String, Plugin> plugins = new LinkedHashMap<>();
     public static final Map<PathClassLoader, Plugin> classLoaders = new HashMap<>();
     public static final Logger logger = new Logger("PM");
 

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CorePlugins.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CorePlugins.java
@@ -6,8 +6,11 @@ import com.aliucord.coreplugins.plugindownloader.PluginDownloader;
 import com.aliucord.PluginManager;
 import com.aliucord.entities.Plugin;
 
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /** CorePlugins Manager */
 public final class CorePlugins {
@@ -21,7 +24,9 @@ public final class CorePlugins {
         corePlugins.put("PluginDownloader", new PluginDownloader());
         corePlugins.put("TokenLogin", new TokenLogin());
 
-        for (Map.Entry<String, Plugin> entry : corePlugins.entrySet()) {
+        List<Map.Entry<String, Plugin>> sortedPlugins = corePlugins.entrySet().stream().sorted(Map.Entry.comparingByKey()).collect(Collectors.toList());
+
+        for (Map.Entry<String, Plugin> entry : sortedPlugins) {
             Plugin p = entry.getValue();
             PluginManager.logger.info("Loading core plugin: " + entry.getKey());
             try {
@@ -34,7 +39,9 @@ public final class CorePlugins {
 
     /** Starts all core plugins */
     public static void startAll(Context context) {
-        for (Map.Entry<String, Plugin> entry : corePlugins.entrySet()) {
+        List<Map.Entry<String, Plugin>> sortedPlugins = corePlugins.entrySet().stream().sorted(Map.Entry.comparingByKey()).collect(Collectors.toList());
+
+        for (Map.Entry<String, Plugin> entry : sortedPlugins) {
             Plugin p = entry.getValue();
             PluginManager.logger.info("Starting core plugin: " + entry.getKey());
             try {

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CorePlugins.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CorePlugins.java
@@ -8,13 +8,14 @@ import com.aliucord.entities.Plugin;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 /** CorePlugins Manager */
 public final class CorePlugins {
-    private static final Map<String, Plugin> corePlugins = new HashMap<>();
+    private static final Map<String, Plugin> corePlugins = new LinkedHashMap<>();
 
     /** Loads all core plugins */
     public static void loadAll(Context context) {
@@ -24,10 +25,7 @@ public final class CorePlugins {
         corePlugins.put("PluginDownloader", new PluginDownloader());
         corePlugins.put("TokenLogin", new TokenLogin());
 
-        List<Entry<String, Plugin>> sortedPlugins = new ArrayList<>(corePlugins.entrySet());
-        sortedPlugins.sort(Entry.comparingByKey());
-
-        for (Entry<String, Plugin> entry : sortedPlugins) {
+        for (Entry<String, Plugin> entry : corePlugins.entrySet()) {
             Plugin p = entry.getValue();
             PluginManager.logger.info("Loading core plugin: " + entry.getKey());
             try {
@@ -40,10 +38,7 @@ public final class CorePlugins {
 
     /** Starts all core plugins */
     public static void startAll(Context context) {
-        List<Entry<String, Plugin>> sortedPlugins = new ArrayList<>(corePlugins.entrySet());
-        sortedPlugins.sort(Entry.comparingByKey());
-
-        for (Entry<String, Plugin> entry : sortedPlugins) {
+        for (Entry<String, Plugin> entry : corePlugins.entrySet()) {
             Plugin p = entry.getValue();
             PluginManager.logger.info("Starting core plugin: " + entry.getKey());
             try {

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CorePlugins.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CorePlugins.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 /** CorePlugins Manager */
 public final class CorePlugins {
@@ -41,7 +40,8 @@ public final class CorePlugins {
 
     /** Starts all core plugins */
     public static void startAll(Context context) {
-        List<Entry<String, Plugin>> sortedPlugins = corePlugins.entrySet().stream().sorted(Entry.comparingByKey()).collect(Collectors.toList());
+        List<Entry<String, Plugin>> sortedPlugins = new ArrayList<>(corePlugins.entrySet());
+        sortedPlugins.sort(Entry.comparingByKey());
 
         for (Entry<String, Plugin> entry : sortedPlugins) {
             Plugin p = entry.getValue();

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CorePlugins.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CorePlugins.java
@@ -6,10 +6,11 @@ import com.aliucord.coreplugins.plugindownloader.PluginDownloader;
 import com.aliucord.PluginManager;
 import com.aliucord.entities.Plugin;
 
-import java.util.Comparator;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 /** CorePlugins Manager */
@@ -24,9 +25,10 @@ public final class CorePlugins {
         corePlugins.put("PluginDownloader", new PluginDownloader());
         corePlugins.put("TokenLogin", new TokenLogin());
 
-        List<Map.Entry<String, Plugin>> sortedPlugins = corePlugins.entrySet().stream().sorted(Map.Entry.comparingByKey()).collect(Collectors.toList());
+        List<Entry<String, Plugin>> sortedPlugins = new ArrayList<>(corePlugins.entrySet());
+        sortedPlugins.sort(Entry.comparingByKey());
 
-        for (Map.Entry<String, Plugin> entry : sortedPlugins) {
+        for (Entry<String, Plugin> entry : sortedPlugins) {
             Plugin p = entry.getValue();
             PluginManager.logger.info("Loading core plugin: " + entry.getKey());
             try {
@@ -39,9 +41,9 @@ public final class CorePlugins {
 
     /** Starts all core plugins */
     public static void startAll(Context context) {
-        List<Map.Entry<String, Plugin>> sortedPlugins = corePlugins.entrySet().stream().sorted(Map.Entry.comparingByKey()).collect(Collectors.toList());
+        List<Entry<String, Plugin>> sortedPlugins = corePlugins.entrySet().stream().sorted(Entry.comparingByKey()).collect(Collectors.toList());
 
-        for (Map.Entry<String, Plugin> entry : sortedPlugins) {
+        for (Entry<String, Plugin> entry : sortedPlugins) {
             Plugin p = entry.getValue();
             PluginManager.logger.info("Starting core plugin: " + entry.getKey());
             try {


### PR DESCRIPTION
This change sorts plugins & coreplugins before loading & starting them. It allows easier finding of log messages, as well as reproducibility on plugin conflicts.