### PR TITLE
Add DiscordRequest to Http

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/Http.java
+++ b/Aliucord/src/main/java/com/aliucord/Http.java
@@ -11,6 +11,10 @@ import androidx.annotation.Nullable;
 
 import com.aliucord.utils.*;
 
+import com.discord.stores.StoreStream;
+import com.discord.utilities.analytics.AnalyticSuperProperties;
+import com.discord.utilities.rest.RestAPI;
+
 import java.io.*;
 import java.lang.reflect.Type;
 import java.math.BigInteger;
@@ -370,6 +374,46 @@ public class Http {
         @Override
         public void close() {
             req.close();
+        }
+    }
+
+    /** Request Builder */
+    public static class DiscordRequest extends Request {
+        /** The connection of this Request */
+        public final HttpURLConnection conn;
+
+        /**
+         * Builds a GET request with the specified QueryBuilder
+         * @param builder QueryBuilder
+         * @throws IOException If an I/O exception occurs
+         */
+        public DiscordRequest(QueryBuilder builder) throws IOException, NoSuchFieldException, IllegalAccessException {
+            this(builder.toString(), "GET");
+        }
+
+        /**
+         * Builds a GET request with the specified url
+         * @param url Url
+         * @throws IOException If an I/O exception occurs
+         */
+        public DiscordRequest(String url) throws IOException, NoSuchFieldException, IllegalAccessException {
+            this(url, "GET");
+        }
+
+        /**
+         * Builds a request with the specified url and method
+         * @param url Url
+         * @param method <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods">HTTP method</a>
+         * @throws IOException If an I/O exception occurs
+         */
+        public DiscordRequest(String url, String method) throws IOException, NoSuchFieldException, IllegalAccessException {
+            super(url, method);
+            conn = (HttpURLConnection) new URL(!url.startsWith("http") ? "https://discord.com/api/v9" + url : url).openConnection();
+            conn.setRequestMethod(method.toUpperCase());
+            conn.addRequestProperty("Authorization", (String) ReflectUtils.getField(StoreStream.getAuthentication(), "authToken"));
+            conn.addRequestProperty("User-Agent", RestAPI.AppHeadersProvider.INSTANCE.getUserAgent());
+            conn.addRequestProperty("X-Super-Properties", AnalyticSuperProperties.INSTANCE.getSuperPropertiesStringBase64());
+            conn.addRequestProperty("Accept", "*/*");
         }
     }
 

--- a/Aliucord/src/main/java/com/aliucord/Http.java
+++ b/Aliucord/src/main/java/com/aliucord/Http.java
@@ -245,9 +245,8 @@ public class Http {
          * Performs a GET request to a Discord route
          * @param route A Discord route, such as `/users/@me`
          * @throws IOException If an I/O exception occurs
-         * @throws NoSuchFieldException,IllegalAccessException If unable to get authentication token
          */
-        public static Request newDiscordRequest(String route) throws IOException, NoSuchFieldException, IllegalAccessException {
+        public static Request newDiscordRequest(String route) throws IOException {
             return newDiscordRequest(route, "GET");
         }
 
@@ -255,14 +254,15 @@ public class Http {
          * Performs a request to a Discord route
          * @param route A Discord route, such as `/users/@me`
          * @throws IOException If an I/O exception occurs
-         * @throws NoSuchFieldException,IllegalAccessException If unable to get authentication token
          */
-        public static Request newDiscordRequest(String route, String method) throws IOException, NoSuchFieldException, IllegalAccessException {
+        public static Request newDiscordRequest(String route, String method) throws IOException {
             Request req = new Request(!route.startsWith("http") ? "https://discord.com/api/v9" + route : route, method);
-            req.setHeader("Authorization", (String) ReflectUtils.getField(StoreStream.getAuthentication(), "authToken"))
-                .setHeader("User-Agent", RestAPI.AppHeadersProvider.INSTANCE.getUserAgent())
+            req.setHeader("User-Agent", RestAPI.AppHeadersProvider.INSTANCE.getUserAgent())
                 .setHeader("X-Super-Properties", AnalyticSuperProperties.INSTANCE.getSuperPropertiesStringBase64())
                 .setHeader("Accept", "*/*");
+            try {
+                req.setHeader("Authorization", (String) ReflectUtils.getField(StoreStream.getAuthentication(), "authToken"));
+            } catch (ReflectiveOperationException ignored){}
             return req;
         }
     }

--- a/Aliucord/src/main/java/com/aliucord/Http.java
+++ b/Aliucord/src/main/java/com/aliucord/Http.java
@@ -379,13 +379,12 @@ public class Http {
 
     /** Request Builder */
     public static class DiscordRequest extends Request {
-        /** The connection of this Request */
-        public final HttpURLConnection conn;
 
         /**
          * Builds a GET request with the specified QueryBuilder
          * @param builder QueryBuilder
          * @throws IOException If an I/O exception occurs
+         * @throws NoSuchFieldException,IllegalAccessException If unable to get authentication token
          */
         public DiscordRequest(QueryBuilder builder) throws IOException, NoSuchFieldException, IllegalAccessException {
             this(builder.toString(), "GET");
@@ -395,6 +394,7 @@ public class Http {
          * Builds a GET request with the specified url
          * @param url Url
          * @throws IOException If an I/O exception occurs
+         * @throws NoSuchFieldException,IllegalAccessException If unable to get authentication token
          */
         public DiscordRequest(String url) throws IOException, NoSuchFieldException, IllegalAccessException {
             this(url, "GET");
@@ -405,11 +405,10 @@ public class Http {
          * @param url Url
          * @param method <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods">HTTP method</a>
          * @throws IOException If an I/O exception occurs
+         * @throws NoSuchFieldException,IllegalAccessException If unable to get authentication token
          */
         public DiscordRequest(String url, String method) throws IOException, NoSuchFieldException, IllegalAccessException {
             super(!url.startsWith("http") ? "https://discord.com/api/v9" + url : url, method);
-            conn = (HttpURLConnection) new URL(!url.startsWith("http") ? "https://discord.com/api/v9" + url : url).openConnection();
-            conn.setRequestMethod(method.toUpperCase());
             setHeader("Authorization", (String) ReflectUtils.getField(StoreStream.getAuthentication(), "authToken"));
             setHeader("User-Agent", RestAPI.AppHeadersProvider.INSTANCE.getUserAgent());
             setHeader("X-Super-Properties", AnalyticSuperProperties.INSTANCE.getSuperPropertiesStringBase64());

--- a/Aliucord/src/main/java/com/aliucord/Http.java
+++ b/Aliucord/src/main/java/com/aliucord/Http.java
@@ -235,7 +235,6 @@ public class Http {
          * Performs a GET request to a Discord route
          * @param builder QueryBuilder
          * @throws IOException If an I/O exception occurs
-         * @throws NoSuchFieldException,IllegalAccessException If unable to get authentication token
          */
         public static Request newDiscordRequest(QueryBuilder builder) throws IOException {
             return newDiscordRequest(builder.toString(), "GET");

--- a/Aliucord/src/main/java/com/aliucord/Http.java
+++ b/Aliucord/src/main/java/com/aliucord/Http.java
@@ -410,10 +410,10 @@ public class Http {
             super(!url.startsWith("http") ? "https://discord.com/api/v9" + url : url, method);
             conn = (HttpURLConnection) new URL(!url.startsWith("http") ? "https://discord.com/api/v9" + url : url).openConnection();
             conn.setRequestMethod(method.toUpperCase());
-            conn.addRequestProperty("Authorization", (String) ReflectUtils.getField(StoreStream.getAuthentication(), "authToken"));
-            conn.addRequestProperty("User-Agent", RestAPI.AppHeadersProvider.INSTANCE.getUserAgent());
-            conn.addRequestProperty("X-Super-Properties", AnalyticSuperProperties.INSTANCE.getSuperPropertiesStringBase64());
-            conn.addRequestProperty("Accept", "*/*");
+            setHeader("Authorization", (String) ReflectUtils.getField(StoreStream.getAuthentication(), "authToken"));
+            setHeader("User-Agent", RestAPI.AppHeadersProvider.INSTANCE.getUserAgent());
+            setHeader("X-Super-Properties", AnalyticSuperProperties.INSTANCE.getSuperPropertiesStringBase64());
+            setHeader("Accept", "*/*");
         }
     }
 

--- a/Aliucord/src/main/java/com/aliucord/Http.java
+++ b/Aliucord/src/main/java/com/aliucord/Http.java
@@ -230,6 +230,41 @@ public class Http {
         public void close() {
             conn.disconnect();
         }
+
+        /**
+         * Performs a GET request to a Discord route
+         * @param builder QueryBuilder
+         * @throws IOException If an I/O exception occurs
+         * @throws NoSuchFieldException,IllegalAccessException If unable to get authentication token
+         */
+        public static Request newDiscordRequest(QueryBuilder builder) throws IOException, NoSuchFieldException, IllegalAccessException {
+            return newDiscordRequest(builder.toString(), "GET");
+        }
+
+        /**
+         * Performs a GET request to a Discord route
+         * @param route A Discord route, such as `/users/@me`
+         * @throws IOException If an I/O exception occurs
+         * @throws NoSuchFieldException,IllegalAccessException If unable to get authentication token
+         */
+        public static Request newDiscordRequest(String route) throws IOException, NoSuchFieldException, IllegalAccessException {
+            return newDiscordRequest(route, "GET");
+        }
+
+        /**
+         * Performs a request to a Discord route
+         * @param route A Discord route, such as `/users/@me`
+         * @throws IOException If an I/O exception occurs
+         * @throws NoSuchFieldException,IllegalAccessException If unable to get authentication token
+         */
+        public static Request newDiscordRequest(String route, String method) throws IOException, NoSuchFieldException, IllegalAccessException {
+            Request req = new Request(!route.startsWith("http") ? "https://discord.com/api/v9" + route : route, method);
+            req.setHeader("Authorization", (String) ReflectUtils.getField(StoreStream.getAuthentication(), "authToken"))
+                .setHeader("User-Agent", RestAPI.AppHeadersProvider.INSTANCE.getUserAgent())
+                .setHeader("X-Super-Properties", AnalyticSuperProperties.INSTANCE.getSuperPropertiesStringBase64())
+                .setHeader("Accept", "*/*");
+            return req;
+        }
     }
 
     /** Response obtained by calling Request.execute() */
@@ -374,45 +409,6 @@ public class Http {
         @Override
         public void close() {
             req.close();
-        }
-    }
-
-    /** Request Builder */
-    public static class DiscordRequest extends Request {
-
-        /**
-         * Builds a GET request with the specified QueryBuilder
-         * @param builder QueryBuilder
-         * @throws IOException If an I/O exception occurs
-         * @throws NoSuchFieldException,IllegalAccessException If unable to get authentication token
-         */
-        public DiscordRequest(QueryBuilder builder) throws IOException, NoSuchFieldException, IllegalAccessException {
-            this(builder.toString(), "GET");
-        }
-
-        /**
-         * Builds a GET request with the specified url
-         * @param url Url
-         * @throws IOException If an I/O exception occurs
-         * @throws NoSuchFieldException,IllegalAccessException If unable to get authentication token
-         */
-        public DiscordRequest(String url) throws IOException, NoSuchFieldException, IllegalAccessException {
-            this(url, "GET");
-        }
-
-        /**
-         * Builds a request with the specified url and method
-         * @param url Url
-         * @param method <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods">HTTP method</a>
-         * @throws IOException If an I/O exception occurs
-         * @throws NoSuchFieldException,IllegalAccessException If unable to get authentication token
-         */
-        public DiscordRequest(String url, String method) throws IOException, NoSuchFieldException, IllegalAccessException {
-            super(!url.startsWith("http") ? "https://discord.com/api/v9" + url : url, method);
-            setHeader("Authorization", (String) ReflectUtils.getField(StoreStream.getAuthentication(), "authToken"));
-            setHeader("User-Agent", RestAPI.AppHeadersProvider.INSTANCE.getUserAgent());
-            setHeader("X-Super-Properties", AnalyticSuperProperties.INSTANCE.getSuperPropertiesStringBase64());
-            setHeader("Accept", "*/*");
         }
     }
 

--- a/Aliucord/src/main/java/com/aliucord/Http.java
+++ b/Aliucord/src/main/java/com/aliucord/Http.java
@@ -237,7 +237,7 @@ public class Http {
          * @throws IOException If an I/O exception occurs
          * @throws NoSuchFieldException,IllegalAccessException If unable to get authentication token
          */
-        public static Request newDiscordRequest(QueryBuilder builder) throws IOException, NoSuchFieldException, IllegalAccessException {
+        public static Request newDiscordRequest(QueryBuilder builder) throws IOException {
             return newDiscordRequest(builder.toString(), "GET");
         }
 

--- a/Aliucord/src/main/java/com/aliucord/Http.java
+++ b/Aliucord/src/main/java/com/aliucord/Http.java
@@ -407,7 +407,7 @@ public class Http {
          * @throws IOException If an I/O exception occurs
          */
         public DiscordRequest(String url, String method) throws IOException, NoSuchFieldException, IllegalAccessException {
-            super(url, method);
+            super(!url.startsWith("http") ? "https://discord.com/api/v9" + url : url, method);
             conn = (HttpURLConnection) new URL(!url.startsWith("http") ? "https://discord.com/api/v9" + url : url).openConnection();
             conn.setRequestMethod(method.toUpperCase());
             conn.addRequestProperty("Authorization", (String) ReflectUtils.getField(StoreStream.getAuthentication(), "authToken"));


### PR DESCRIPTION
Automatically adds headers and allows you to remove the `https://discord.com/api/v9` base url