### PR TITLE
feat(SettingsUtils): missing operations

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/SettingsUtils.java
+++ b/Aliucord/src/main/java/com/aliucord/SettingsUtils.java
@@ -17,7 +17,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-/** Utility class to store and retrieve preferences */
+/**
+ * Utility class to store and retrieve preferences
+ * This is only used for Aliucord internally
+ */
 @SuppressWarnings("unused")
 public class SettingsUtils {
     private static final SharedPreferences prefs = Utils.getAppContext().getSharedPreferences("aliucord", Context.MODE_PRIVATE);
@@ -39,6 +42,18 @@ public class SettingsUtils {
      */
     public static void setBool(String key, boolean val) {
         prefs.edit().putBoolean(key, val).apply();
+    }
+
+    /**
+     * Toggle a boolean item in the preferences
+     * @param key Key of the item
+     * @param defValue Value to set if not found. This is not flipped
+     * @return Flipped value if found, else the defValue
+     */
+    public static boolean toggleBool(String key, boolean defValue) {
+        boolean value = !prefs.getBoolean(key, !defValue);
+        prefs.edit().putBoolean(key, value).apply();
+        return value;
     }
 
     /**
@@ -166,14 +181,41 @@ public class SettingsUtils {
     }
 
     /**
-     * Gets All Settings
+     * Gets all settings
      * @return All settings
      */
-    public static Map<String, ?> getAllSettings(String prefix) {
+    public static Map<String, ?> getAll() {
+        return prefs.getAll();
+    }
+
+    /**
+     * Gets all settings with a prefix
+     * @return All settings
+     */
+    public static Map<String, ?> getAll(String prefix) {
         return prefs.getAll()
                 .entrySet()
                 .stream()
                 .filter(stringEntry -> (stringEntry.getKey()).startsWith(prefix) && stringEntry.getValue() != null)
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
+     * Checks if a setting exists
+     * @param key Key of the item
+     */
+    public static boolean exists(String key) {
+        return prefs.contains(key);
+    }
+
+    /**
+     * Deletes a setting
+     * @param key Key of the item
+     * @return Whether the item existed
+     */
+    public static boolean delete(String key) {
+        boolean exists = prefs.contains(key);
+        prefs.edit().remove(key).apply();
+        return exists;
     }
 }

--- a/Aliucord/src/main/java/com/aliucord/SettingsUtilsJSON.kt
+++ b/Aliucord/src/main/java/com/aliucord/SettingsUtilsJSON.kt
@@ -44,7 +44,7 @@ class SettingsUtilsJSON(private val plugin: String) {
         }
     }
 
-    private fun getPreferenceSettings() = SettingsUtils.getAllSettings(keyPrefix)
+    private fun getPreferenceSettings() = SettingsUtils.getAll(keyPrefix)
 
     private fun writeData() {
         if (settings.length() > 0) {


### PR DESCRIPTION
Until we migrate ac's internal settings to use json this will have to do

I thought Manti would add these from my earlier pr (#117) but apparently not.