### PR TITLE
feat(Injector): disable hidden api policy

### DIFF
--- a/Injector/src/main/java/com/aliucord/injector/Injector.java
+++ b/Injector/src/main/java/com/aliucord/injector/Injector.java
@@ -48,6 +48,7 @@ public final class Injector {
         PineConfig.disableHiddenApiPolicyForPlatformDomain = false;
         Pine.disableJitInline();
         Pine.disableProfileSaver();
+        // Use our own hidden api bypass since pine bypass causes crashes according to Juby
         disableHiddenApiPolicy();
 
         try {

--- a/Injector/src/main/java/com/aliucord/injector/Injector.java
+++ b/Injector/src/main/java/com/aliucord/injector/Injector.java
@@ -213,11 +213,13 @@ public final class Injector {
     }
 
     /**
-     * Disables the Android Hidden API by adding an exemption for everything ("L")
+     * Disables the Android Hidden API by adding an exemption for everything ("L", the prefix of all class references, e.g. Ljava/lang/String)
      * Works by getting reflection methods through reflection,
      * then invoking those methods to get and invoke a setter for hidden API exemptions.
-     * This works because the VM thinks its internals calling the hidden method,
-     * since you're invoking reflection methods using reflection.
+     * This works because the VM thinks it's internals calling the hidden method,
+     * since we're invoking reflection methods using reflection.
+     * 
+     * See https://weishu.me/2019/03/16/another-free-reflection-above-android-p/ (chinese)
      */
     private static void disableHiddenApiPolicy() {
         // Not supported as it doesn't exist
@@ -227,6 +229,7 @@ public final class Injector {
             var mForName = Class.class.getDeclaredMethod("forName", String.class);
             var mGetDeclaredMethod = Class.class.getDeclaredMethod("getDeclaredMethod", String.class, Class[].class);
 
+            // https://android.googlesource.com/platform/libcore/+/master/libart/src/main/java/dalvik/system/VMRuntime.java
             var cVMRuntime = mForName.invoke(null, "dalvik.system.VMRuntime");
             var mGetRuntime = (Method) mGetDeclaredMethod.invoke(cVMRuntime, "getRuntime", null);
             Objects.requireNonNull(mGetRuntime, "Failed to get getRuntime()!");

--- a/Injector/src/main/java/com/aliucord/injector/Injector.java
+++ b/Injector/src/main/java/com/aliucord/injector/Injector.java
@@ -220,6 +220,9 @@ public final class Injector {
      * since you're invoking reflection methods using reflection.
      */
     private static void disableHiddenApiPolicy() {
+        // Not supported as it doesn't exist
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return;
+
         try {
             var mForName = Class.class.getDeclaredMethod("forName", String.class);
             var mGetDeclaredMethod = Class.class.getDeclaredMethod("getDeclaredMethod", String.class, Class[].class);

--- a/Injector/src/main/java/com/aliucord/injector/Injector.java
+++ b/Injector/src/main/java/com/aliucord/injector/Injector.java
@@ -212,6 +212,13 @@ public final class Injector {
         return true;
     }
 
+    /**
+     * Disables the Android Hidden API by adding an exemption for everything ("L")
+     * Works by getting reflection methods through reflection,
+     * then invoking those methods to get and invoke a setter for hidden API exemptions.
+     * This works because the VM thinks its internals calling the hidden method,
+     * since you're invoking reflection methods using reflection.
+     */
     private static void disableHiddenApiPolicy() {
         try {
             var mForName = Class.class.getDeclaredMethod("forName", String.class);


### PR DESCRIPTION
Very cursed code, but it works
Any further reflection calls on hidden methods will succeed during the apps lifetime