### PR TITLE
[skip ci] Add "Blocked Discord Tracking/Analytics" to README features

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Pine does not support `x86` or `x86_64` architectures, and thus Aliucord does no
     -   Toggle on and off, configure or uninstall your plugins via the plugins page
     -   Minimum Discord versions for plugins so no breaking changes are sent out to outdated Discord versions
 -   In-app updater to keep Aliucord and your plugins up-to-date
+-   Blocked Discord Tracking/Analytics
 -   Crash logging!
     -   In-app crash log page to give a more native feel
     -   Logs are also saved to `Aliucord/crashlogs` for easy access outside of the app


### PR DESCRIPTION
*hopefully will prevent people asking if aliucord does it/asking for no track plugins*
but lets be honest people wont read this either