### PR TITLE
Fix rotate crash in settings

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/fragments/AppFragmentProxy.java
+++ b/Aliucord/src/main/java/com/aliucord/fragments/AppFragmentProxy.java
@@ -13,12 +13,14 @@ public class AppFragmentProxy extends FragmentProxy {
     private Fragment mFragment;
 
     @Override
-    @SuppressWarnings("ConstantConditions")
     public Fragment getmFragment() {
         if (mFragment == null) {
-            String id = ((AppActivity) getActivity()).c().getStringExtra("AC_FRAGMENT_ID");
-            mFragment = FragmentProxy.fragments.get(id);
-            FragmentProxy.fragments.remove(id);
+            var activity = (AppActivity) getActivity();
+            if (activity != null) {
+                String id = activity.c().getStringExtra("AC_FRAGMENT_ID");
+                mFragment = FragmentProxy.fragments.get(id);
+                FragmentProxy.fragments.remove(id);
+            }
         }
         if (mFragment != null) return mFragment;
         return super.getmFragment();

--- a/Aliucord/src/main/java/com/aliucord/fragments/FragmentProxy.java
+++ b/Aliucord/src/main/java/com/aliucord/fragments/FragmentProxy.java
@@ -525,6 +525,7 @@ public class FragmentProxy extends Fragment implements AppComponent {
         // Horrible hack but hey it is better than crash
         if (mFragment == null) {
             if (!didHack) {
+                Main.logger.warn("Proxied fragment is null. Closing...");
                 didHack = true;
                 Utils.getAppActivity().onBackPressed();
             }

--- a/Aliucord/src/main/java/com/aliucord/fragments/FragmentProxy.java
+++ b/Aliucord/src/main/java/com/aliucord/fragments/FragmentProxy.java
@@ -22,6 +22,7 @@ import androidx.lifecycle.*;
 import androidx.loader.app.LoaderManager;
 
 import com.aliucord.Main;
+import com.aliucord.Utils;
 import com.discord.app.AppComponent;
 
 import java.io.FileDescriptor;
@@ -510,6 +511,7 @@ public class FragmentProxy extends Fragment implements AppComponent {
         getmFragment().dump(prefix, fd, writer, args);
     }
 
+    private boolean didHack = false;
     public Fragment getmFragment() {
         if (mFragment == null) {
             Bundle bundle = getArguments();
@@ -519,6 +521,16 @@ public class FragmentProxy extends Fragment implements AppComponent {
                 fragments.remove(id);
             }
         }
+
+        // Horrible hack but hey it is better than crash
+        if (mFragment == null) {
+            if (!didHack) {
+                didHack = true;
+                Utils.getAppActivity().onBackPressed();
+            }
+            return new Fragment();
+        }
+
         return mFragment;
     }
 }


### PR DESCRIPTION
Very hacky fix. On rotate, simply simulate backpress (Close page) and
return new Fragment. Fixes crash, but kicks you out of the settings page
on rotate.