### PR TITLE
hopefully fix upload progress jumping right into 99%

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/UploadSize.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/UploadSize.kt
@@ -120,6 +120,8 @@ internal class UploadSize : Plugin(Manifest("UploadSize")) {
                         .setHeader("Content-Type", upload.mimeType)
                         .setHeader("Content-Length", upload.contentLength.toString())
                     uploadReq.conn.doOutput = true
+                    uploadReq.conn.setFixedLengthStreamingMode(upload.contentLength)
+
                     uploadReq.conn.outputStream.use { outputStream ->
                         var totalBytes: Long = 0
                         var currentBytes: Int


### PR DESCRIPTION
https://stackoverflow.com/a/18204596

> To upload data to a web server, configure the connection for output using setDoOutput(true).
For best performance, you should call either setFixedLengthStreamingMode(int) when the body length is known in advance, or setChunkedStreamingMode(int) when it is not. Otherwise HttpURLConnection will be forced to buffer the complete request body in memory before it is transmitted, wasting (and possibly exhausting) heap and increasing latency.

(I of course tested it)
andro will explode