### PR TITLE
fix: use id if discrim gone

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/rn/RNAPI.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/rn/RNAPI.kt
@@ -20,6 +20,7 @@ class RNAPI : Plugin(Manifest("RNAPI")) {
         patchNextCallAdapter()
         patchUser()
         patchUserProfile()
+        patchDefaultAvatars()
     }
 
     override fun start(context: Context?) {}


### PR DESCRIPTION
Added a patch that makes default avatar use the user id if their discriminator is gone