### PR TITLE
Enable experiment for editing server profile, banner, and bio by default

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/Main.java
+++ b/Aliucord/src/main/java/com/aliucord/Main.java
@@ -248,7 +248,7 @@ public final class Main {
         // set default values for experiments
         var experiments = StoreStream.getExperiments();
         var overrides = StoreExperiments.access$getExperimentOverrides$p(experiments);
-        for (var key : new String[]{"2021-10_android_attachment_bottom_sheet", "2021-11_guild_communication_disabled_users", "2021-11_guild_communication_disabled_guilds"}) {
+        for (var key : new String[]{"2021-10_android_attachment_bottom_sheet", "2021-11_guild_communication_disabled_users", "2021-11_guild_communication_disabled_guilds", "2021-10_premium_guild_member_profiles"}) {
             if (!overrides.containsKey(key)) experiments.setOverride(key, 1);
         }
 


### PR DESCRIPTION
I was inspired by e63cc053bcfa1cf012375587a13f9481bb185f6a to check out some other experiments and found an experiment that allows me to edit my server pfp/banner/bio, so it would be nice to have it enabled by default. I don't have building setup, but this should work.