### PR TITLE
Use new slash commands API

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CorePlugins.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CorePlugins.kt
@@ -1,9 +1,10 @@
 package com.aliucord.coreplugins
 
 import android.content.Context
-import com.aliucord.PluginManager
 import com.aliucord.coreplugins.plugindownloader.PluginDownloader
 import com.aliucord.coreplugins.rn.RNAPI
+import com.aliucord.coreplugins.slashcommandsfix.SlashCommandsFix
+import com.aliucord.PluginManager
 
 /** CorePlugins Manager */
 object CorePlugins {

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CorePlugins.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CorePlugins.kt
@@ -25,7 +25,8 @@ object CorePlugins {
         PrivateChannelsListScroll(),
         MembersListFix(),
         Pronouns(),
-        GifPreviewFix()
+        GifPreviewFix(),
+        SlashCommandsFix()
     )
 
     /** Loads all core plugins */

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
@@ -142,6 +142,7 @@ final class SlashCommandsFix extends Plugin {
             StoreApplicationCommands$requestApplicationCommands$1.class.getDeclaredMethod("invoke"),
             new PreHook(param -> {
                 var this_ = (StoreApplicationCommands$requestApplicationCommands$1) param.thisObject;
+
                 if (this_.$guildId == null) {
                     return;
                 }
@@ -156,6 +157,7 @@ final class SlashCommandsFix extends Plugin {
             StoreApplicationCommands$requestApplications$1.class.getDeclaredMethod("invoke"),
             new PreHook(param -> {
                 var this_ = (StoreApplicationCommands$requestApplications$1) param.thisObject;
+
                 if (this_.$guildId == null) {
                     return;
                 }
@@ -170,6 +172,7 @@ final class SlashCommandsFix extends Plugin {
             StoreApplicationCommands$requestApplicationCommandsQuery$1.class.getDeclaredMethod("invoke"),
             new PreHook(param -> {
                 var this_ = (StoreApplicationCommands$requestApplicationCommandsQuery$1) param.thisObject;
+
                 if (this_.$guildId == null) {
                     return;
                 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
@@ -25,6 +25,8 @@ import com.discord.stores.StoreApplicationCommands$requestApplications$1;
 import com.discord.stores.StoreApplicationCommandsKt;
 import com.discord.stores.StoreStream;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -206,6 +208,12 @@ final class SlashCommandsFix extends Plugin {
         if (requestSource == RequestSource.GUILD) {
             try {
                 var applications = new ArrayList(applicationIndex.applications);
+                Collections.sort(applications, new Comparator<Application>() {
+                    @Override
+                    public int compare(Application left, Application right) {
+                        return left.getName().compareTo(right.getName());
+                    }
+                });
                 applications.add(((BuiltInCommandsProvider) ReflectUtils.getField(storeApplicationCommands, "builtInCommandsProvider")).getBuiltInApplication());
                 var handleGuildApplicationsUpdateMethod = StoreApplicationCommands.class.getDeclaredMethod("handleGuildApplicationsUpdate", List.class);
                 handleGuildApplicationsUpdateMethod.setAccessible(true);

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
@@ -1,0 +1,166 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins;
+
+import android.content.Context;
+import com.aliucord.entities.Plugin;
+import com.aliucord.Http;
+import com.aliucord.patcher.PreHook;
+import com.aliucord.utils.ReflectUtils;
+import com.discord.api.commands.Application;
+import com.discord.api.commands.ApplicationCommand;
+import com.discord.api.commands.GuildApplicationCommands;
+import com.discord.models.deserialization.gson.InboundGatewayGsonParser;
+import com.discord.stores.StoreApplicationCommands;
+import com.discord.stores.StoreApplicationCommands$requestApplicationCommands$1;
+import com.discord.stores.StoreApplicationCommands$requestApplicationCommandsQuery$1;
+import com.discord.stores.StoreApplicationCommands$requestApplications$1;
+import com.discord.stores.StoreStream;
+import com.google.gson.Gson;
+import java.util.HashMap;
+import java.util.List;
+
+final class SlashCommandsFix extends Plugin {
+    private class CachedGuild {
+        public GuildApplicationCommands applicationIndex;
+
+        CachedGuild(GuildApplicationCommands applicationIndex) {
+            this.applicationIndex = applicationIndex;
+        }
+    }
+
+    private HashMap<Long, CachedGuild> cachedGuilds;
+    private Gson gson;
+
+    SlashCommandsFix() {
+        super(new Manifest("SlashCommandsFix"));
+
+        this.cachedGuilds = new HashMap<Long, CachedGuild>();
+    }
+
+    @Override
+    public void start(Context context) throws Throwable {
+        this.gson = (Gson) ReflectUtils.getField(InboundGatewayGsonParser.class, null, "gatewayGsonInstance");
+
+        var storeApplicationCommands = StoreStream.getApplicationCommands();
+
+        // Browsing commands (when just a '/' is typed)
+        patcher.patch(
+            StoreApplicationCommands$requestApplicationCommands$1.class.getDeclaredMethod("invoke"),
+            new PreHook(param -> {
+                var this_ = (StoreApplicationCommands$requestApplicationCommands$1) param.thisObject;
+                logger.debug(String.format("requestApplicationCommands lambda %d %d", this_.$guildId, this_.$applicationId));
+                if (this_.$applicationId == null) {
+                    return;
+                }
+
+                this.passCommandData(this_.this$0, this_.$guildId, "discoverCommandsNonce");
+                param.setResult(null);
+            })
+        );
+
+        // Requesting applications present in the guild
+        patcher.patch(
+            StoreApplicationCommands$requestApplications$1.class.getDeclaredMethod("invoke"),
+            new PreHook(param -> {
+                var this_ = (StoreApplicationCommands$requestApplications$1) param.thisObject;
+                logger.debug(String.format("requestApplications lambda %d", this_.$guildId));
+                if (this_.$guildId == null) {
+                    return;
+                }
+
+                this.passCommandData(this_.this$0, this_.$guildId, "applicationNonce");
+                param.setResult(null);
+            })
+        );
+
+        // Autocompleting commands
+        patcher.patch(
+            StoreApplicationCommands$requestApplicationCommandsQuery$1.class.getDeclaredMethod("invoke"),
+            new PreHook(param -> {
+                var this_ = (StoreApplicationCommands$requestApplicationCommandsQuery$1) param.thisObject;
+                if (this_.$guildId == null) {
+                    return;
+                }
+
+                this.passCommandData(this_.this$0, this_.$guildId, "queryNonce");
+                param.setResult(null);
+            })
+        );
+    }
+
+    @Override
+    public void stop(Context context) {}
+
+    // Upcasting Object generates a warning and we need that to get private fields with reflection
+    @SuppressWarnings("unchecked")
+    private void passCommandData(StoreApplicationCommands storeApplicationCommands, long guildId, String nonceFieldName) {
+        // TODO: Cache the fields as they are requested every time this runs
+
+        String nonce = null;
+        try {
+            // Generate fake (never used) nonce
+            nonce = (String) ReflectUtils.invokeMethod(storeApplicationCommands, "generateNonce", new Object[] {});
+            // Set appropriate nonce so handleApplicationCommandsUpdate knows what to do with the commands
+            ReflectUtils.setField(storeApplicationCommands, nonceFieldName, nonce);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        GuildApplicationCommands applicationIndex = null;
+        var cachedGuild = this.cachedGuilds.get(guildId);
+        if (cachedGuild != null) {
+            // Reuse cached guild
+            applicationIndex = cachedGuild.applicationIndex;
+        } else {
+            try {
+                // Request application index
+                applicationIndex = Http.Request.newDiscordRequest(String.format("/guilds/%d/application-command-index", guildId))
+                    .execute()
+                    .json(gson, GuildApplicationCommands.class);
+
+                // Fix up attributes that are needed by the client but aren't sent via the new API
+
+                // Guild ID
+                ReflectUtils.setField(applicationIndex, "guildId", guildId);
+
+                // Command count
+                var applications = (List<Application>) ReflectUtils.getField(applicationIndex, "applications");
+                var applicationCommands = (List<ApplicationCommand>) ReflectUtils.getField(applicationIndex, "applicationCommands");
+                for (var application: applications) {
+                    var applicationId = (long) ReflectUtils.getField(application, "id");
+                    // TODO: Calculate this for all commands beforehand so there's no nested loop
+                    var commandCount = applicationCommands
+                        .stream()
+                        .filter(applicationCommand -> {
+                            try {
+                                return (long) ReflectUtils.getField(applicationCommand, "applicationId") == applicationId;
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                        .count();
+                    ReflectUtils.setField(application, "commandCount", (int) commandCount);
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            this.cachedGuilds.put(guildId, new CachedGuild(applicationIndex));
+        }
+
+        try {
+            // Set nonce so handleApplicationCommandsUpdate can recognize it
+            ReflectUtils.setField(applicationIndex, "nonce", nonce);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        // TODO: Reimplement this so the fake nonce jank is not necessary and gateway updates can be implemented
+        storeApplicationCommands.handleApplicationCommandsUpdate(applicationIndex);
+    }
+}

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
@@ -12,6 +12,7 @@ import com.aliucord.Http;
 import com.aliucord.patcher.Patcher;
 import com.aliucord.patcher.PreHook;
 import com.aliucord.utils.ReflectUtils;
+import com.aliucord.utils.GsonUtils;
 import com.discord.api.commands.Application;
 import com.discord.api.commands.ApplicationCommand;
 import com.discord.api.commands.GuildApplicationCommands;
@@ -43,7 +44,6 @@ final class SlashCommandsFix extends Plugin {
     }
 
     private HashMap<Long, CachedGuild> cachedGuilds;
-    private Gson gson;
 
     SlashCommandsFix() {
         super(new Manifest("SlashCommandsFix"));
@@ -53,8 +53,6 @@ final class SlashCommandsFix extends Plugin {
 
     @Override
     public void start(Context context) throws Throwable {
-        this.gson = (Gson) ReflectUtils.getField(InboundGatewayGsonParser.class, null, "gatewayGsonInstance");
-
         var storeApplicationCommands = StoreStream.getApplicationCommands();
 
         // Browsing commands (when just a '/' is typed)
@@ -118,7 +116,7 @@ final class SlashCommandsFix extends Plugin {
                 // Request application index
                 applicationIndex = Http.Request.newDiscordRNRequest(String.format("/guilds/%d/application-command-index", guildId))
                     .execute()
-                    .json(gson, GuildApplicationCommands.class);
+                    .json(GsonUtils.getGsonRestApi(), GuildApplicationCommands.class);
 
                 // Fix up attributes that are needed by the client but aren't sent via the new API
 

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
@@ -17,6 +17,7 @@ import com.discord.models.commands.Application;
 import com.discord.models.commands.ApplicationCommand;
 import com.discord.models.commands.ApplicationCommandOption;
 import com.discord.models.commands.RemoteApplicationCommand;
+import com.discord.stores.BuiltInCommandsProvider;
 import com.discord.stores.StoreApplicationCommands;
 import com.discord.stores.StoreApplicationCommands$requestApplicationCommands$1;
 import com.discord.stores.StoreApplicationCommands$requestApplicationCommandsQuery$1;
@@ -204,9 +205,11 @@ final class SlashCommandsFix extends Plugin {
         // Pass the information to StoreApplicationCommands
         if (requestSource == RequestSource.GUILD) {
             try {
+                var applications = new ArrayList(applicationIndex.applications);
+                applications.add(((BuiltInCommandsProvider) ReflectUtils.getField(storeApplicationCommands, "builtInCommandsProvider")).getBuiltInApplication());
                 var handleGuildApplicationsUpdateMethod = StoreApplicationCommands.class.getDeclaredMethod("handleGuildApplicationsUpdate", List.class);
                 handleGuildApplicationsUpdateMethod.setAccessible(true);
-                handleGuildApplicationsUpdateMethod.invoke(storeApplicationCommands, applicationIndex.applications);
+                handleGuildApplicationsUpdateMethod.invoke(storeApplicationCommands, applications);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
@@ -54,7 +54,6 @@ final class SlashCommandsFix extends Plugin {
             StoreApplicationCommands$requestApplicationCommands$1.class.getDeclaredMethod("invoke"),
             new PreHook(param -> {
                 var this_ = (StoreApplicationCommands$requestApplicationCommands$1) param.thisObject;
-                logger.debug(String.format("requestApplicationCommands lambda %d %d", this_.$guildId, this_.$applicationId));
                 if (this_.$applicationId == null) {
                     return;
                 }
@@ -69,7 +68,6 @@ final class SlashCommandsFix extends Plugin {
             StoreApplicationCommands$requestApplications$1.class.getDeclaredMethod("invoke"),
             new PreHook(param -> {
                 var this_ = (StoreApplicationCommands$requestApplications$1) param.thisObject;
-                logger.debug(String.format("requestApplications lambda %d", this_.$guildId));
                 if (this_.$guildId == null) {
                     return;
                 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
@@ -9,6 +9,7 @@ package com.aliucord.coreplugins;
 import android.content.Context;
 import com.aliucord.entities.Plugin;
 import com.aliucord.Http;
+import com.aliucord.patcher.Patcher;
 import com.aliucord.patcher.PreHook;
 import com.aliucord.utils.ReflectUtils;
 import com.discord.api.commands.Application;
@@ -49,7 +50,7 @@ final class SlashCommandsFix extends Plugin {
         var storeApplicationCommands = StoreStream.getApplicationCommands();
 
         // Browsing commands (when just a '/' is typed)
-        patcher.patch(
+        Patcher.addPatch(
             StoreApplicationCommands$requestApplicationCommands$1.class.getDeclaredMethod("invoke"),
             new PreHook(param -> {
                 var this_ = (StoreApplicationCommands$requestApplicationCommands$1) param.thisObject;
@@ -64,7 +65,7 @@ final class SlashCommandsFix extends Plugin {
         );
 
         // Requesting applications present in the guild
-        patcher.patch(
+        Patcher.addPatch(
             StoreApplicationCommands$requestApplications$1.class.getDeclaredMethod("invoke"),
             new PreHook(param -> {
                 var this_ = (StoreApplicationCommands$requestApplications$1) param.thisObject;
@@ -79,7 +80,7 @@ final class SlashCommandsFix extends Plugin {
         );
 
         // Autocompleting commands
-        patcher.patch(
+        Patcher.addPatch(
             StoreApplicationCommands$requestApplicationCommandsQuery$1.class.getDeclaredMethod("invoke"),
             new PreHook(param -> {
                 var this_ = (StoreApplicationCommands$requestApplicationCommandsQuery$1) param.thisObject;

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
@@ -194,7 +194,6 @@ final class SlashCommandsFix extends Plugin {
                     .execute()
                     .json(GsonUtils.getGsonRestApi(), ApiApplicationIndex.class)
                     .toModel();
-                logger.debug(GsonUtils.toJson(applicationIndex));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
@@ -62,7 +62,7 @@ final class SlashCommandsFix extends Plugin {
             StoreApplicationCommands$requestApplicationCommands$1.class.getDeclaredMethod("invoke"),
             new PreHook(param -> {
                 var this_ = (StoreApplicationCommands$requestApplicationCommands$1) param.thisObject;
-                if (this_.$applicationId == null) {
+                if (this_.$guildId == null) {
                     return;
                 }
 

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
@@ -34,6 +34,12 @@ final class SlashCommandsFix extends Plugin {
         }
     }
 
+    private enum RequestSource {
+        GUILD,
+        BROWSE,
+        QUERY;
+    }
+
     private HashMap<Long, CachedGuild> cachedGuilds;
     private Gson gson;
 
@@ -58,7 +64,7 @@ final class SlashCommandsFix extends Plugin {
                     return;
                 }
 
-                this.passCommandData(this_.this$0, this_.$guildId, "discoverCommandsNonce");
+                this.passCommandData(this_.this$0, this_.$guildId, RequestSource.BROWSE);
                 param.setResult(null);
             })
         );
@@ -72,7 +78,7 @@ final class SlashCommandsFix extends Plugin {
                     return;
                 }
 
-                this.passCommandData(this_.this$0, this_.$guildId, "applicationNonce");
+                this.passCommandData(this_.this$0, this_.$guildId, RequestSource.GUILD);
                 param.setResult(null);
             })
         );
@@ -86,7 +92,7 @@ final class SlashCommandsFix extends Plugin {
                     return;
                 }
 
-                this.passCommandData(this_.this$0, this_.$guildId, "queryNonce");
+                this.passCommandData(this_.this$0, this_.$guildId, RequestSource.QUERY);
                 param.setResult(null);
             })
         );
@@ -97,7 +103,7 @@ final class SlashCommandsFix extends Plugin {
 
     // Upcasting Object generates a warning and we need that to get private fields with reflection
     @SuppressWarnings("unchecked")
-    private void passCommandData(StoreApplicationCommands storeApplicationCommands, long guildId, String nonceFieldName) {
+    private void passCommandData(StoreApplicationCommands storeApplicationCommands, long guildId, RequestSource requestSource) {
         // TODO: Cache the fields as they are requested every time this runs
 
         String nonce = null;
@@ -105,6 +111,18 @@ final class SlashCommandsFix extends Plugin {
             // Generate fake (never used) nonce
             nonce = (String) ReflectUtils.invokeMethod(storeApplicationCommands, "generateNonce", new Object[] {});
             // Set appropriate nonce so handleApplicationCommandsUpdate knows what to do with the commands
+            String nonceFieldName = null;
+            switch (requestSource) {
+                case GUILD:
+                    nonceFieldName = "applicationNonce";
+                    break;
+                case BROWSE:
+                    nonceFieldName = "discoverCommandsNonce";
+                    break;
+                case QUERY:
+                    nonceFieldName = "queryNonce";
+                    break;
+            }
             ReflectUtils.setField(storeApplicationCommands, nonceFieldName, nonce);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
@@ -119,7 +119,7 @@ final class SlashCommandsFix extends Plugin {
         } else {
             try {
                 // Request application index
-                applicationIndex = Http.Request.newDiscordRequest(String.format("/guilds/%d/application-command-index", guildId))
+                applicationIndex = Http.Request.newDiscordRNRequest(String.format("/guilds/%d/application-command-index", guildId))
                     .execute()
                     .json(gson, GuildApplicationCommands.class);
 

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/SlashCommandsFix.java
@@ -23,7 +23,6 @@ import com.discord.stores.StoreApplicationCommands$requestApplicationCommandsQue
 import com.discord.stores.StoreApplicationCommands$requestApplications$1;
 import com.discord.stores.StoreApplicationCommandsKt;
 import com.discord.stores.StoreStream;
-import com.google.gson.Gson;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiApplication.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiApplication.java
@@ -6,17 +6,23 @@
 
 package com.aliucord.coreplugins.slashcommandsfix;
 
+import com.discord.models.user.User;
+import com.discord.stores.StoreStream;
+import java.util.Optional;
+
 class ApiApplication {
     public final long id;
     public final String name;
     public final String icon;
     public final ApiPermissions permissions;
+    public final Long botId;
 
     public ApiApplication() {
         this.id = 0;
         this.name = null;
         this.icon = null;
         this.permissions = null;
+        this.botId = null;
     }
 
     public Application toModel(int commandCount) {
@@ -26,6 +32,8 @@ class ApiApplication {
         } else {
             permissions = new Permissions(null, null, null);
         }
-        return new Application(this.id, this.name, this.icon, permissions, commandCount);
+        var usersStore = StoreStream.getUsers();
+        Optional<User> botUser = Optional.ofNullable(this.botId).map(userId -> usersStore.getUsers().get(userId));
+        return new Application(this.id, this.name, this.icon, permissions, commandCount, botUser);
     }
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiApplication.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiApplication.java
@@ -28,9 +28,9 @@ class ApiApplication {
     public Application toModel(int commandCount) {
         Permissions permissions = null;
         if (this.permissions != null) {
-            permissions = this.permissions.toModel();
+            permissions = this.permissions.toModel(Optional.empty());
         } else {
-            permissions = new Permissions(null, null, null);
+            permissions = new Permissions(null, null, null, null);
         }
         var usersStore = StoreStream.getUsers();
         Optional<User> botUser = Optional.ofNullable(this.botId).map(userId -> usersStore.getUsers().get(userId));

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiApplication.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiApplication.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins.slashcommandsfix;
+
+class ApiApplication {
+    public final long id;
+    public final String name;
+    public final String icon;
+    public final ApiPermissions permissions;
+
+    public ApiApplication() {
+        this.id = 0;
+        this.name = null;
+        this.icon = null;
+        this.permissions = null;
+    }
+
+    public Application toModel(int commandCount) {
+        Permissions permissions = null;
+        if (this.permissions != null) {
+            permissions = this.permissions.toModel();
+        } else {
+            permissions = new Permissions(null, null, null);
+        }
+        return new Application(this.id, this.name, this.icon, permissions, commandCount);
+    }
+}

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiApplicationCommand.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiApplicationCommand.java
@@ -10,6 +10,7 @@ import com.discord.models.commands.ApplicationCommand;
 import com.discord.stores.StoreApplicationCommandsKt;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 class ApiApplicationCommand {
@@ -19,6 +20,7 @@ class ApiApplicationCommand {
     public final String description;
     public final List<com.discord.api.commands.ApplicationCommandOption> options;
     public final ApiPermissions permissions;
+    public final Long defaultMemberPermissions;
     public final Long guildId;
     public final String version;
 
@@ -29,6 +31,7 @@ class ApiApplicationCommand {
         this.description = null;
         this.options = null;
         this.permissions = null;
+        this.defaultMemberPermissions = null;
         this.guildId = null;
         this.version = null;
     }
@@ -43,10 +46,11 @@ class ApiApplicationCommand {
             .map(option -> StoreApplicationCommandsKt.toSlashCommandOption(option))
             .collect(Collectors.toList());
         Permissions permissions = null;
+        var defaultMemberPermissions = Optional.ofNullable(this.defaultMemberPermissions);
         if (this.permissions != null) {
-            permissions = this.permissions.toModel();
+            permissions = this.permissions.toModel(defaultMemberPermissions);
         } else {
-            permissions = new Permissions(null, null, null);
+            permissions = new Permissions(null, null, null, defaultMemberPermissions);
         }
         return new RemoteApplicationCommand(String.valueOf(this.id), this.applicationId, this.name, this.description, options, permissions, this.guildId, this.version);
     }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiApplicationCommand.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiApplicationCommand.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins.slashcommandsfix;
+
+import com.discord.models.commands.ApplicationCommand;
+import com.discord.stores.StoreApplicationCommandsKt;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class ApiApplicationCommand {
+    public final long id;
+    public final long applicationId;
+    public final String name;
+    public final String description;
+    public final List<com.discord.api.commands.ApplicationCommandOption> options;
+    public final ApiPermissions permissions;
+    public final String version;
+
+    public ApiApplicationCommand() {
+        this.id = 0;
+        this.applicationId = 0;
+        this.name = null;
+        this.description = null;
+        this.options = null;
+        this.permissions = null;
+        this.version = null;
+    }
+
+    public ApplicationCommand toModel() {
+        var apiOptions = this.options;
+        if (apiOptions == null) {
+            apiOptions = new ArrayList<>();
+        }
+        var options = apiOptions
+            .stream()
+            .map(option -> StoreApplicationCommandsKt.toSlashCommandOption(option))
+            .collect(Collectors.toList());
+        Permissions permissions = null;
+        if (this.permissions != null) {
+            permissions = this.permissions.toModel();
+        } else {
+            permissions = new Permissions(null, null, null);
+        }
+        return new RemoteApplicationCommand(String.valueOf(this.id), this.applicationId, this.name, this.description, options, permissions, this.version);
+    }
+}

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiApplicationCommand.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiApplicationCommand.java
@@ -19,6 +19,7 @@ class ApiApplicationCommand {
     public final String description;
     public final List<com.discord.api.commands.ApplicationCommandOption> options;
     public final ApiPermissions permissions;
+    public final Long guildId;
     public final String version;
 
     public ApiApplicationCommand() {
@@ -28,6 +29,7 @@ class ApiApplicationCommand {
         this.description = null;
         this.options = null;
         this.permissions = null;
+        this.guildId = null;
         this.version = null;
     }
 
@@ -46,6 +48,6 @@ class ApiApplicationCommand {
         } else {
             permissions = new Permissions(null, null, null);
         }
-        return new RemoteApplicationCommand(String.valueOf(this.id), this.applicationId, this.name, this.description, options, permissions, this.version);
+        return new RemoteApplicationCommand(String.valueOf(this.id), this.applicationId, this.name, this.description, options, permissions, this.guildId, this.version);
     }
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiApplicationIndex.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiApplicationIndex.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins.slashcommandsfix;
+
+import com.discord.models.commands.ApplicationCommand;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+class ApiApplicationIndex {
+    public List<ApiApplication> applications;
+    public List<ApiApplicationCommand> applicationCommands;
+
+    public ApiApplicationIndex() {
+        this.applications = null;
+        this.applicationCommands = null;
+    }
+
+    public ApplicationIndex toModel() {
+        var applicationCommandCounts = new HashMap<Long, Integer>();
+        for (var applicationCommand: this.applicationCommands) {
+            var count = applicationCommandCounts.getOrDefault(applicationCommand.applicationId, 0);
+            count += 1;
+            applicationCommandCounts.put(applicationCommand.applicationId, count);
+        }
+
+        var applications = new ArrayList<Application>();
+        for (var application: this.applications) {
+            applications.add(application.toModel(applicationCommandCounts.getOrDefault(application.id, 0)));
+        }
+        var applicationCommands = new ArrayList<ApplicationCommand>();
+        for (var applicationCommand: this.applicationCommands) {
+            applicationCommands.add(applicationCommand.toModel());
+        }
+
+        return new ApplicationIndex(applications, applicationCommands);
+    }
+}

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiGuildApplicationCommandIndexUpdate.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiGuildApplicationCommandIndexUpdate.java
@@ -1,0 +1,15 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins.slashcommandsfix;
+
+class ApiGuildApplicationCommandIndexUpdate {
+    public long guildId;
+
+    public ApiGuildApplicationCommandIndexUpdate() {
+        this.guildId = 0;
+    }
+}

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiPermissions.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiPermissions.java
@@ -20,7 +20,7 @@ class ApiPermissions {
         this.channels = null;
     }
 
-    public Permissions toModel() {
-        return new Permissions(Optional.ofNullable(user), roles, channels);
+    public Permissions toModel(Optional<Long> defaultMemberPermissions) {
+        return new Permissions(Optional.ofNullable(user), roles, channels, defaultMemberPermissions);
     }
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiPermissions.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApiPermissions.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins.slashcommandsfix;
+
+import java.util.Map;
+import java.util.Optional;
+
+class ApiPermissions {
+    public Boolean user;
+    public Map<Long, Boolean> roles;
+    public Map<Long, Boolean> channels;
+
+    public ApiPermissions() {
+        this.user = null;
+        this.roles = null;
+        this.channels = null;
+    }
+
+    public Permissions toModel() {
+        return new Permissions(Optional.ofNullable(user), roles, channels);
+    }
+}

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Application.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Application.java
@@ -1,0 +1,16 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins.slashcommandsfix;
+
+class Application extends com.discord.models.commands.Application {
+    public Permissions permissions_;
+
+    public Application(long id, String name, String icon, Permissions permissions, int commandCount) {
+        super(id, name, icon, null, commandCount, null, false);
+        this.permissions_ = permissions;
+    }
+}

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Application.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Application.java
@@ -6,11 +6,16 @@
 
 package com.aliucord.coreplugins.slashcommandsfix;
 
+import com.aliucord.Logger;
+import com.discord.models.user.User;
+import com.discord.utilities.user.UserUtils;
+import java.util.Optional;
+
 class Application extends com.discord.models.commands.Application {
     public Permissions permissions_;
 
-    public Application(long id, String name, String icon, Permissions permissions, int commandCount) {
-        super(id, name, icon, null, commandCount, null, false);
+    public Application(long id, String name, String icon, Permissions permissions, int commandCount, Optional<User> botUser) {
+        super(id, name, icon, null, commandCount, botUser.map(user -> UserUtils.INSTANCE.synthesizeApiUser(user)).orElse(null), false);
         this.permissions_ = permissions;
     }
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndex.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndex.java
@@ -1,0 +1,20 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins.slashcommandsfix;
+
+import com.discord.models.commands.ApplicationCommand;
+import java.util.List;
+
+class ApplicationIndex {
+    public List<Application> applications;
+    public List<ApplicationCommand> applicationCommands;
+
+    public ApplicationIndex(List<Application> applications, List<ApplicationCommand> applicationCommands) {
+        this.applications = applications;
+        this.applicationCommands = applicationCommands;
+    }
+}

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndexSource.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndexSource.java
@@ -12,4 +12,5 @@ interface ApplicationIndexSource {
     String getEndpoint();
     ApplicationIndex getIndex(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes);
     void putIndex(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes, ApplicationIndex index);
+    void cleanCache(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes);
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndexSource.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndexSource.java
@@ -1,0 +1,15 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins.slashcommandsfix;
+
+import java.util.Map;
+
+interface ApplicationIndexSource {
+    String getEndpoint();
+    ApplicationIndex getIndex(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes);
+    void putIndex(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes, ApplicationIndex index);
+}

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndexSourceDm.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndexSourceDm.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins.slashcommandsfix;
+
+import java.util.Map;
+
+class ApplicationIndexSourceDm implements ApplicationIndexSource {
+    long userId;
+
+    public ApplicationIndexSourceDm(long userId) {
+        this.userId = userId;
+    }
+
+    @Override
+    public String getEndpoint() {
+        return String.format("/channels/%d/application-command-index", this.userId);
+    }
+
+    @Override
+    public ApplicationIndex getIndex(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes) {
+        return dmApplicationIndexes.get(this.userId);
+    }
+
+    @Override
+    public void putIndex(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes, ApplicationIndex index) {
+        dmApplicationIndexes.put(this.userId, index);
+    }
+}

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndexSourceDm.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndexSourceDm.java
@@ -29,4 +29,9 @@ class ApplicationIndexSourceDm implements ApplicationIndexSource {
     public void putIndex(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes, ApplicationIndex index) {
         dmApplicationIndexes.put(this.channelId, index);
     }
+
+    @Override
+    public void cleanCache(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes) {
+        dmApplicationIndexes.remove(this.channelId);
+    }
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndexSourceDm.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndexSourceDm.java
@@ -9,24 +9,24 @@ package com.aliucord.coreplugins.slashcommandsfix;
 import java.util.Map;
 
 class ApplicationIndexSourceDm implements ApplicationIndexSource {
-    long userId;
+    long channelId;
 
-    public ApplicationIndexSourceDm(long userId) {
-        this.userId = userId;
+    public ApplicationIndexSourceDm(long channelId) {
+        this.channelId = channelId;
     }
 
     @Override
     public String getEndpoint() {
-        return String.format("/channels/%d/application-command-index", this.userId);
+        return String.format("/channels/%d/application-command-index", this.channelId);
     }
 
     @Override
     public ApplicationIndex getIndex(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes) {
-        return dmApplicationIndexes.get(this.userId);
+        return dmApplicationIndexes.get(this.channelId);
     }
 
     @Override
     public void putIndex(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes, ApplicationIndex index) {
-        dmApplicationIndexes.put(this.userId, index);
+        dmApplicationIndexes.put(this.channelId, index);
     }
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndexSourceGuild.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndexSourceGuild.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins.slashcommandsfix;
+
+import java.util.Map;
+
+class ApplicationIndexSourceGuild implements ApplicationIndexSource {
+    long guildId;
+
+    public ApplicationIndexSourceGuild(long guildId) {
+        this.guildId = guildId;
+    }
+
+    @Override
+    public String getEndpoint() {
+        return String.format("/guilds/%d/application-command-index", this.guildId);
+    }
+
+    @Override
+    public ApplicationIndex getIndex(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes) {
+        return guildApplicationIndexes.get(this.guildId);
+    }
+
+    @Override
+    public void putIndex(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes, ApplicationIndex index) {
+        guildApplicationIndexes.put(this.guildId, index);
+    }
+}

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndexSourceGuild.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/ApplicationIndexSourceGuild.java
@@ -29,4 +29,9 @@ class ApplicationIndexSourceGuild implements ApplicationIndexSource {
     public void putIndex(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes, ApplicationIndex index) {
         guildApplicationIndexes.put(this.guildId, index);
     }
+
+    @Override
+    public void cleanCache(Map<Long, ApplicationIndex> guildApplicationIndexes, Map<Long, ApplicationIndex> dmApplicationIndexes) {
+        guildApplicationIndexes.remove(this.guildId);
+    }
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -56,7 +56,7 @@ final class Patches {
             if (this.permissions != null) {
                 permissions = this.permissions.toModel();
             } else {
-                permissions = new Permissions();
+                permissions = new Permissions(null, null, null);
             }
             return new Application(this.id, this.name, this.icon, permissions, commandCount);
         }
@@ -94,7 +94,7 @@ final class Patches {
             if (this.permissions != null) {
                 permissions = this.permissions.toModel();
             } else {
-                permissions = new Permissions();
+                permissions = new Permissions(null, null, null);
             }
             return new RemoteApplicationCommand(String.valueOf(this.id), this.applicationId, this.name, this.description, options, permissions, this.version);
         }
@@ -162,13 +162,18 @@ final class Patches {
         public Map<Long, Boolean> channels;
 
         public Permissions(Optional<Boolean> user, Map<Long, Boolean> roles, Map<Long, Boolean> channels) {
+            if (user == null) {
+                user = Optional.empty();
+            }
+            if (roles == null) {
+                roles = new HashMap();
+            }
+            if (channels == null) {
+                channels = new HashMap();
+            }
             this.user = user;
             this.roles = roles;
             this.channels = channels;
-        }
-
-        public Permissions() {
-            this(Optional.empty(), new HashMap(), new HashMap());
         }
 
         public boolean checkFor(List<Long> roleIds, long channelId, Guild guild, long memberPermissions, MeUser user) {

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -50,6 +50,8 @@ final class Patches {
             Permissions permissions = null;
             if (this.permissions != null) {
                 permissions = this.permissions.toModel();
+            } else {
+                permissions = new Permissions();
             }
             return new Application(this.id, this.name, this.icon, permissions, commandCount);
         }
@@ -86,6 +88,8 @@ final class Patches {
             Permissions permissions = null;
             if (this.permissions != null) {
                 permissions = this.permissions.toModel();
+            } else {
+                permissions = new Permissions();
             }
             return new RemoteApplicationCommand(String.valueOf(this.id), this.applicationId, this.name, this.description, options, permissions, this.version);
         }
@@ -156,6 +160,10 @@ final class Patches {
             this.user = user;
             this.roles = roles;
             this.channels = channels;
+        }
+
+        public Permissions() {
+            this(null, new HashMap(), new HashMap());
         }
 
         public boolean checkFor(List<Long> roleIds, long channelId, long guildId) {

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -325,6 +325,7 @@ final class Patches {
                 var memberPermissions = storePermissions.getGuildPermissions()
                     .get(guildId);
                 var guild = storeGuilds.getGuild(guildId);
+
                 return !(applicationCommand instanceof RemoteApplicationCommand)
                     || (application.get().permissions_.checkFor(roleIds, channelId, guild, memberPermissions, user)
                         && ((RemoteApplicationCommand) applicationCommand).permissions_.checkFor(roleIds, channelId, guild, memberPermissions, user));

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -278,7 +278,6 @@ final class Patches {
                 var channelId = selectedChannel.k();
                 var guildId = selectedChannel.i();
                 var applicationId = applicationCommand.getApplicationId();
-                this.logger.debug(String.format("Checking permissions for command %s (%s): user %d with %d roles, channel %d, guild %d", applicationCommand.getId(), applicationCommand.getName(), userId, roles.size(), channelId, guildId));
                 var optionalApplication = this.requestApplicationIndex(guildId)
                     .applications
                     .stream()

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -83,6 +83,8 @@ final class Patches {
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
+
+                return null;
             })
         );
 

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -64,6 +64,7 @@ final class Patches {
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
+
                 param.setResult(null);
             })
         );
@@ -113,6 +114,7 @@ final class Patches {
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
+
                 param.setResult(null);
             })
         );
@@ -133,6 +135,7 @@ final class Patches {
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
+
                 param.setResult(null);
             })
         );

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -17,13 +17,16 @@ import com.aliucord.utils.GsonUtils;
 import com.aliucord.utils.ReflectUtils;
 import com.discord.models.commands.ApplicationCommand;
 import com.discord.models.commands.ApplicationCommandKt;
+import com.discord.models.commands.ApplicationCommandLocalSendData;
 import com.discord.stores.BuiltInCommandsProvider;
 import com.discord.stores.StoreApplicationCommands;
 import com.discord.stores.StoreApplicationCommands$handleDmUserApplication$1;
 import com.discord.stores.StoreApplicationCommands$requestApplicationCommands$1;
 import com.discord.stores.StoreApplicationCommands$requestApplicationCommandsQuery$1;
 import com.discord.stores.StoreApplicationCommands$requestApplications$1;
+import com.discord.stores.StoreApplicationInteractions;
 import com.discord.stores.StoreStream;
+import com.discord.utilities.messagesend.MessageResult;
 import com.discord.utilities.permissions.PermissionUtils;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,11 +34,8 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import com.discord.utilities.messagesend.MessageResult;
-import com.discord.models.commands.ApplicationCommandLocalSendData;
 import kotlin.jvm.functions.Function0;
 import kotlin.jvm.functions.Function1;
-import com.discord.stores.StoreApplicationInteractions;
 
 final class Patches {
     private static final int INTERACTION_APPLICATION_COMMAND_INVALID_VERSION_ERROR_CODE = 50035;

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -62,7 +62,7 @@ final class Patches {
                 }
 
                 try {
-                    this.passCommandData(this_.this$0, new ApplicationIndexSourceGuild(this_.$guildId), RequestSource.GUILD);
+                    this.passCommandData(this_.this$0, new ApplicationIndexSourceGuild(this_.$guildId), RequestSource.INITIAL);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
@@ -82,7 +82,7 @@ final class Patches {
                     .k();
 
                 try {
-                    this.passCommandData(this_.this$0, new ApplicationIndexSourceDm(channelId), RequestSource.GUILD);
+                    this.passCommandData(this_.this$0, new ApplicationIndexSourceDm(channelId), RequestSource.INITIAL);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
                 }
@@ -190,7 +190,7 @@ final class Patches {
         var applicationIndex = this.requestApplicationIndex(applicationIndexSource);
 
         switch (requestSource) {
-            case GUILD:
+            case INITIAL:
                 var applications = new ArrayList<com.discord.models.commands.Application>(applicationIndex.applications);
                 Collections.sort(applications, new Comparator<com.discord.models.commands.Application>() {
                     @Override

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -8,12 +8,12 @@ package com.aliucord.coreplugins.slashcommandsfix;
 
 import android.content.Context;
 import com.aliucord.Http;
+import com.aliucord.Logger;
 import com.aliucord.patcher.InsteadHook;
 import com.aliucord.patcher.Patcher;
 import com.aliucord.patcher.PreHook;
 import com.aliucord.utils.GsonUtils;
 import com.aliucord.utils.ReflectUtils;
-import com.aliucord.Logger;
 import com.discord.models.commands.ApplicationCommand;
 import com.discord.models.commands.ApplicationCommandKt;
 import com.discord.models.commands.ApplicationCommandOption;

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -84,7 +84,7 @@ final class Patches {
         public ApplicationCommand toModel() {
             var apiOptions = this.options;
             if (apiOptions == null) {
-                apiOptions = new ArrayList();
+                apiOptions = new ArrayList<>();
             }
             var options = apiOptions
                 .stream()
@@ -166,10 +166,10 @@ final class Patches {
                 user = Optional.empty();
             }
             if (roles == null) {
-                roles = new HashMap();
+                roles = new HashMap<>();
             }
             if (channels == null) {
-                channels = new HashMap();
+                channels = new HashMap<>();
             }
             this.user = user;
             this.roles = roles;
@@ -232,10 +232,11 @@ final class Patches {
     Logger logger;
 
     Patches(Logger logger) {
-        this.guildApplicationIndexes = new HashMap();
+        this.guildApplicationIndexes = new HashMap<>();
         this.logger = logger;
     }
 
+    @SuppressWarnings("unchecked")
     public void loadPatches(Context context) throws Throwable {
         var storeApplicationCommands = StoreStream.getApplicationCommands();
         var storeChannelsSelected = StoreStream.getChannelsSelected();
@@ -330,8 +331,6 @@ final class Patches {
         );
     }
 
-    // Upcasting Object generates a warning and we need that to get private fields with reflection
-    @SuppressWarnings("unchecked")
     private void passCommandData(StoreApplicationCommands storeApplicationCommands, long guildId, RequestSource requestSource) throws Exception {
         // TODO: Cache the fields as they are requested every time this runs
 
@@ -339,10 +338,10 @@ final class Patches {
 
         switch (requestSource) {
             case GUILD:
-                var applications = new ArrayList(applicationIndex.applications);
-                Collections.sort(applications, new Comparator<Application>() {
+                var applications = new ArrayList<com.discord.models.commands.Application>(applicationIndex.applications);
+                Collections.sort(applications, new Comparator<com.discord.models.commands.Application>() {
                     @Override
-                    public int compare(Application left, Application right) {
+                    public int compare(com.discord.models.commands.Application left, com.discord.models.commands.Application right) {
                         return left.getName().compareTo(right.getName());
                     }
                 });

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -7,6 +7,7 @@
 package com.aliucord.coreplugins.slashcommandsfix;
 
 import android.content.Context;
+import com.aliucord.api.GatewayAPI;
 import com.aliucord.Http;
 import com.aliucord.Logger;
 import com.aliucord.patcher.InsteadHook;
@@ -176,6 +177,11 @@ final class Patches {
                         && ((RemoteApplicationCommand) applicationCommand).permissions_.checkFor(roleIds, channelId, guild, memberPermissions, user));
             })
         );
+
+        GatewayAPI.onEvent("GUILD_APPLICATION_COMMAND_INDEX_UPDATE", ApiGuildApplicationCommandIndexUpdate.class, guildApplicationCommandIndexUpdate -> {
+            this.guildApplicationIndexes.remove(guildApplicationCommandIndexUpdate.guildId);
+            return null;
+        });
     }
 
     private void passCommandData(StoreApplicationCommands storeApplicationCommands, ApplicationIndexSource applicationIndexSource, RequestSource requestSource) throws Exception {

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -13,6 +13,7 @@ import com.aliucord.Logger;
 import com.aliucord.patcher.InsteadHook;
 import com.aliucord.patcher.Patcher;
 import com.aliucord.patcher.PreHook;
+import com.aliucord.Utils;
 import com.aliucord.utils.GsonUtils;
 import com.aliucord.utils.ReflectUtils;
 import com.discord.models.commands.ApplicationCommand;
@@ -203,6 +204,8 @@ final class Patches {
                             applicationIndexSource = new ApplicationIndexSourceDm(channelId);
                         }
                         this.cleanApplicationIndexCache(applicationIndexSource);
+
+                        Utils.showToast("This command is outdated, please try again");
                     }
                 }
             })

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -164,6 +164,7 @@ final class Patches {
             var userPermission = this.user;
             var rolePermission = this.calculateRolePermission(roleIds);
             var defaultRolePermission = this.roles.getOrDefault(guildId, true);
+
             return ((channelPermission != null && channelPermission) || (channelPermission == null && defaultChannelPermission)) &&
                 ((userPermission != null && userPermission) ||
                     (rolePermission != null && rolePermission) ||

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -18,11 +18,12 @@ import com.discord.models.commands.ApplicationCommand;
 import com.discord.models.commands.ApplicationCommandKt;
 import com.discord.stores.BuiltInCommandsProvider;
 import com.discord.stores.StoreApplicationCommands;
+import com.discord.stores.StoreApplicationCommands$handleDmUserApplication$1;
 import com.discord.stores.StoreApplicationCommands$requestApplicationCommands$1;
 import com.discord.stores.StoreApplicationCommands$requestApplicationCommandsQuery$1;
-import com.discord.stores.StoreApplicationCommands$handleDmUserApplication$1;
 import com.discord.stores.StoreApplicationCommands$requestApplications$1;
 import com.discord.stores.StoreStream;
+import com.discord.utilities.permissions.PermissionUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -150,6 +151,7 @@ final class Patches {
                 var channel = storeChannelsSelected.getSelectedChannel();
                 var guildId = channel.i();
 
+                // Allow all commands in DMs
                 if (guildId == 0) {
                     return true;
                 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -253,7 +253,11 @@ final class Patches {
                     return;
                 }
 
-                this.passCommandData(this_.this$0, this_.$guildId, RequestSource.BROWSE);
+                try {
+                    this.passCommandData(this_.this$0, this_.$guildId, RequestSource.BROWSE);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
                 param.setResult(null);
             })
         );
@@ -268,7 +272,11 @@ final class Patches {
                     return;
                 }
 
-                this.passCommandData(this_.this$0, this_.$guildId, RequestSource.GUILD);
+                try {
+                    this.passCommandData(this_.this$0, this_.$guildId, RequestSource.GUILD);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
                 param.setResult(null);
             })
         );
@@ -283,7 +291,11 @@ final class Patches {
                     return;
                 }
 
-                this.passCommandData(this_.this$0, this_.$guildId, RequestSource.QUERY);
+                try {
+                    this.passCommandData(this_.this$0, this_.$guildId, RequestSource.QUERY);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
                 param.setResult(null);
             })
         );
@@ -320,14 +332,13 @@ final class Patches {
 
     // Upcasting Object generates a warning and we need that to get private fields with reflection
     @SuppressWarnings("unchecked")
-    private void passCommandData(StoreApplicationCommands storeApplicationCommands, long guildId, RequestSource requestSource) {
+    private void passCommandData(StoreApplicationCommands storeApplicationCommands, long guildId, RequestSource requestSource) throws Exception {
         // TODO: Cache the fields as they are requested every time this runs
 
         var applicationIndex = this.requestApplicationIndex(guildId);
 
-        // Pass the information to StoreApplicationCommands
-        if (requestSource == RequestSource.GUILD) {
-            try {
+        switch (requestSource) {
+            case GUILD:
                 var applications = new ArrayList(applicationIndex.applications);
                 Collections.sort(applications, new Comparator<Application>() {
                     @Override
@@ -339,23 +350,19 @@ final class Patches {
                 var handleGuildApplicationsUpdateMethod = StoreApplicationCommands.class.getDeclaredMethod("handleGuildApplicationsUpdate", List.class);
                 handleGuildApplicationsUpdateMethod.setAccessible(true);
                 handleGuildApplicationsUpdateMethod.invoke(storeApplicationCommands, applications);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        } else if (requestSource == RequestSource.BROWSE || requestSource == RequestSource.QUERY) {
-            try {
-                if (requestSource == RequestSource.BROWSE) {
-                    var handleDiscoverCommandsUpdateMethod = StoreApplicationCommands.class.getDeclaredMethod("handleDiscoverCommandsUpdate", List.class);
-                    handleDiscoverCommandsUpdateMethod.setAccessible(true);
-                    handleDiscoverCommandsUpdateMethod.invoke(storeApplicationCommands, applicationIndex.applicationCommands);
-                } else if (requestSource == RequestSource.QUERY) {
-                    var handleQueryCommandsUpdateMethod = StoreApplicationCommands.class.getDeclaredMethod("handleQueryCommandsUpdate", List.class);
-                    handleQueryCommandsUpdateMethod.setAccessible(true);
-                    handleQueryCommandsUpdateMethod.invoke(storeApplicationCommands, applicationIndex.applicationCommands);
-                }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+                break;
+
+            case BROWSE:
+                var handleDiscoverCommandsUpdateMethod = StoreApplicationCommands.class.getDeclaredMethod("handleDiscoverCommandsUpdate", List.class);
+                handleDiscoverCommandsUpdateMethod.setAccessible(true);
+                handleDiscoverCommandsUpdateMethod.invoke(storeApplicationCommands, applicationIndex.applicationCommands);
+                break;
+
+            case QUERY:
+                var handleQueryCommandsUpdateMethod = StoreApplicationCommands.class.getDeclaredMethod("handleQueryCommandsUpdate", List.class);
+                handleQueryCommandsUpdateMethod.setAccessible(true);
+                handleQueryCommandsUpdateMethod.invoke(storeApplicationCommands, applicationIndex.applicationCommands);
+                break;
         }
     }
 

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -311,21 +311,6 @@ final class Patches {
                         && ((RemoteApplicationCommand) applicationCommand).permissions_.checkFor(roleIds, channelId, guild, memberPermissions, user));
             })
         );
-
-        // Patcher.addPatch(
-        //     StoreGatewayConnection.class.getDeclaredMethod("handleDispatch", String.class, Object.class),
-        //     new PreHook(param -> {
-        //         var eventName = (String) param.args[0];
-        //         var eventData = param.args[1];
-
-        //         logger.debug(eventName);
-        //         if (eventName != "GUILD_APPLICATION_COMMAND_INDEX_UPDATE") {
-        //             return;
-        //         }
-        //         logger.debug(eventData.getClass().getName());
-        //         param.setResult(null);
-        //     })
-        // );
     }
 
     // Upcasting Object generates a warning and we need that to get private fields with reflection

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Patches.java
@@ -293,6 +293,7 @@ final class Patches {
                 }
 
                 try {
+                    ReflectUtils.setField(this_.this$0, "query", this_.$query);
                     this.passCommandData(this_.this$0, this_.$guildId, RequestSource.QUERY);
                 } catch (Exception e) {
                     throw new RuntimeException(e);

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Permissions.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/Permissions.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins.slashcommandsfix;
+
+import com.discord.api.permission.Permission;
+import com.discord.models.guild.Guild;
+import com.discord.models.user.MeUser;
+import com.discord.utilities.permissions.PermissionUtils;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+class Permissions {
+    public Optional<Boolean> user;
+    public Map<Long, Boolean> roles;
+    public Map<Long, Boolean> channels;
+
+    public Permissions(Optional<Boolean> user, Map<Long, Boolean> roles, Map<Long, Boolean> channels) {
+        if (user == null) {
+            user = Optional.empty();
+        }
+        if (roles == null) {
+            roles = new HashMap<>();
+        }
+        if (channels == null) {
+            channels = new HashMap<>();
+        }
+        this.user = user;
+        this.roles = roles;
+        this.channels = channels;
+    }
+
+    public boolean checkFor(List<Long> roleIds, long channelId, Guild guild, long memberPermissions, MeUser user) {
+        var guildId = guild.component7();
+        var defaultChannelPermission = this.channels.getOrDefault(guildId - 1, true);
+        var channelPermission = Optional.ofNullable(this.channels.get(channelId))
+            .orElse(defaultChannelPermission);
+        var defaultRolePermission = this.roles.getOrDefault(guildId, true);
+        var rolePermission = this.calculateRolePermission(roleIds, defaultRolePermission);
+        var userPermission = this.user.orElse(true);
+        var administratorPermissions = PermissionUtils.canAndIsElevated(Permission.ADMINISTRATOR, memberPermissions, user.getMfaEnabled(), guild.getMfaLevel());
+
+        return administratorPermissions || (channelPermission && (userPermission || rolePermission));
+    }
+
+    private boolean calculateRolePermission(List<Long> roleIds, boolean defaultPermission) {
+        var calculatedRolePermission = defaultPermission;
+        for (var roleId: roleIds) {
+            var rolePermission = this.roles.get(roleId);
+            if (rolePermission != null) {
+                calculatedRolePermission = rolePermission;
+                if (rolePermission) {
+                    break;
+                }
+            }
+        }
+        return calculatedRolePermission;
+    }
+}

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/RemoteApplicationCommand.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/RemoteApplicationCommand.java
@@ -13,7 +13,7 @@ class RemoteApplicationCommand extends com.discord.models.commands.RemoteApplica
     public Permissions permissions_;
 
     public RemoteApplicationCommand(String id, long applicationId, String name, String description, List<ApplicationCommandOption> options, Permissions permissions, Long guildId, String version) {
-        super(id, applicationId, name, description, options, guildId, version, true, null, null); // TODO: defaultPermissions
+        super(id, applicationId, name, description, options, guildId, version, null, null, null);
         this.permissions_ = permissions;
     }
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/RemoteApplicationCommand.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/RemoteApplicationCommand.java
@@ -12,8 +12,8 @@ import java.util.List;
 class RemoteApplicationCommand extends com.discord.models.commands.RemoteApplicationCommand {
     public Permissions permissions_;
 
-    public RemoteApplicationCommand(String id, long applicationId, String name, String description, List<ApplicationCommandOption> options, Permissions permissions, String version) {
-        super(id, applicationId, name, description, options, null, version, true, null, null); // TODO: defaultPermissions
+    public RemoteApplicationCommand(String id, long applicationId, String name, String description, List<ApplicationCommandOption> options, Permissions permissions, Long guildId, String version) {
+        super(id, applicationId, name, description, options, guildId, version, true, null, null); // TODO: defaultPermissions
         this.permissions_ = permissions;
     }
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/RemoteApplicationCommand.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/RemoteApplicationCommand.java
@@ -1,0 +1,19 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins.slashcommandsfix;
+
+import com.discord.models.commands.ApplicationCommandOption;
+import java.util.List;
+
+class RemoteApplicationCommand extends com.discord.models.commands.RemoteApplicationCommand {
+    public Permissions permissions_;
+
+    public RemoteApplicationCommand(String id, long applicationId, String name, String description, List<ApplicationCommandOption> options, Permissions permissions, String version) {
+        super(id, applicationId, name, description, options, null, version, true, null, null); // TODO: defaultPermissions
+        this.permissions_ = permissions;
+    }
+}

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/RequestSource.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/RequestSource.java
@@ -7,7 +7,7 @@
 package com.aliucord.coreplugins.slashcommandsfix;
 
 enum RequestSource {
-    GUILD,
+    INITIAL,
     BROWSE,
     QUERY;
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/RequestSource.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/RequestSource.java
@@ -1,0 +1,13 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins.slashcommandsfix;
+
+enum RequestSource {
+    GUILD,
+    BROWSE,
+    QUERY;
+}

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/SlashCommandsFix.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/slashcommandsfix/SlashCommandsFix.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Aliucord, an Android Discord client mod.
+ * Copyright (c) 2021 Juby210 & Vendicated
+ * Licensed under the Open Software License version 3.0
+ */
+
+package com.aliucord.coreplugins.slashcommandsfix;
+
+import android.content.Context;
+import com.aliucord.entities.Plugin;
+import de.robv.android.xposed.XposedBridge;
+
+final public class SlashCommandsFix extends Plugin {
+    public SlashCommandsFix() {
+        super(new Manifest("SlashCommandsFix"));
+    }
+
+    @Override
+    public void start(Context context) throws Throwable {
+        XposedBridge.makeClassInheritable(com.discord.models.commands.Application.class);
+        XposedBridge.makeClassInheritable(com.discord.models.commands.RemoteApplicationCommand.class);
+
+        new Patches(this.logger).loadPatches(context);
+    }
+
+    @Override
+    public void stop(Context context) {}
+}

--- a/Aliucord/src/main/java/com/aliucord/utils/RNSuperProperties.kt
+++ b/Aliucord/src/main/java/com/aliucord/utils/RNSuperProperties.kt
@@ -42,7 +42,7 @@ object RNSuperProperties {
     val superPropertiesBase64: String = Base64.encodeToString(superProperties.toString().toByteArray(), 2)
 
     // update to latest Beta branch sometimes
-    const val versionCode = 183109
-    const val versionString = "183.9 - rn"
+    const val versionCode = 219205
+    const val versionString = "219.5 - rn"
     const val userAgent = "Discord-Android/$versionCode;RNA"
 }

--- a/Aliucord/src/main/java/com/aliucord/utils/RNSuperProperties.kt
+++ b/Aliucord/src/main/java/com/aliucord/utils/RNSuperProperties.kt
@@ -42,7 +42,7 @@ object RNSuperProperties {
     val superPropertiesBase64: String = Base64.encodeToString(superProperties.toString().toByteArray(), 2)
 
     // update to latest Beta branch sometimes
-    const val versionCode = 219205
-    const val versionString = "219.5 - rn"
+    const val versionCode = 218111
+    const val versionString = "218.11 - rn"
     const val userAgent = "Discord-Android/$versionCode;RNA"
 }


### PR DESCRIPTION
Switches to the new slash commands API, as the old one is no longer functional.

<img src="https://github.com/Aliucord/Aliucord/assets/33988779/593f35e7-721e-4a2e-968b-5b8fac09edc5" width="300px">

Fixes #412.

---

The `GUILD_APPLICATION_COMMAND_INDEX_UPDATE` event is currently not handled, so if an application updates it's commands the client needs to be restarted to see the changes.

I plan to implement this, as well as other improvements (see the unresolved `TODO`s in the code), as a separate MR, so basic functionality is brought to users sooner, but if it's necessary I can do it as part of this one.

There's also something that looks like a bug, but I'm unsure if it actually is one, as I don't know how the commands worked when the old API was functional - the command list does not come up immediately after typing `/`, it's required to tap on one of the bot icons to see it:

<img src="https://github.com/Aliucord/Aliucord/assets/33988779/e23d916e-159e-4138-8285-bd5d4bdb9d09" width="300px">

I will try to research this more, but when I asked about this on Discord, Juby210 said that's how he remembers it working.