### PR TITLE
feat: installation components versions API

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/updater/ManagerBuild.kt
+++ b/Aliucord/src/main/java/com/aliucord/updater/ManagerBuild.kt
@@ -1,0 +1,66 @@
+package com.aliucord.updater
+
+import com.aliucord.Logger
+import com.aliucord.utils.GsonUtils
+import com.aliucord.utils.GsonUtils.fromJson
+import com.aliucord.utils.SemVer
+import java.lang.Exception
+
+/**
+ * Version checking for various install-time utilities that were used to install the app.
+ */
+@Suppress("unused", "MemberVisibilityCanBePrivate")
+object ManagerBuild {
+    var metadata: InstallMetadata? = null
+        private set
+
+    /**
+     * Whether this installation has *at least* a specific version of smali patches applied to it.
+     */
+    @JvmStatic
+    fun hasPatches(version: String): Boolean =
+        (metadata?.patchesVersion ?: SemVer.Zero) >= SemVer.parse(version)
+
+    /**
+     * Whether this installation has *at least* a specific version of injector added to it.
+     */
+    @JvmStatic
+    fun hasInjector(version: String): Boolean =
+        (metadata?.injectorVersion ?: SemVer.Zero) >= SemVer.parse(version)
+
+    /**
+     * Whether this installation was patched with *at least* a specific version of manager
+     * @param version If null, then any version matches.
+     */
+    @JvmStatic
+    fun installedWithManager(version: String?): Boolean {
+        return if (version == null) {
+            metadata != null
+        } else {
+            (metadata?.managerVersion ?: SemVer.Zero) >= SemVer.parse(version)
+        }
+    }
+
+    init {
+        try {
+            // Manager adds this to the APK root
+            val stream = this.javaClass.classLoader?.getResourceAsStream("aliucord.json")
+
+            if (stream != null) {
+                metadata = GsonUtils.gson.fromJson(
+                    stream.bufferedReader(),
+                    InstallMetadata::class.java
+                )
+            }
+        } catch (e: Exception) {
+            Logger("ManagerBuild").warn("Failed to parse Manager install metadata", e)
+        }
+    }
+
+    data class InstallMetadata(
+        val customManager: Boolean,
+        val managerVersion: SemVer,
+        val injectorVersion: SemVer,
+        val patchesVersion: SemVer,
+    )
+}

--- a/Aliucord/src/main/java/com/aliucord/utils/GsonUtils.kt
+++ b/Aliucord/src/main/java/com/aliucord/utils/GsonUtils.kt
@@ -21,6 +21,7 @@ import b.i.d.e as GsonBuilder
  * [Original source](https://github.com/google/gson/blob/main/gson/src/main/java/com/google/gson/annotations/SerializedName.java)
  */
 typealias SerializedName = b.i.d.p.b
+typealias JsonAdapter = b.i.d.p.a
 
 object GsonUtils {
 

--- a/Aliucord/src/main/java/com/aliucord/utils/SemVer.kt
+++ b/Aliucord/src/main/java/com/aliucord/utils/SemVer.kt
@@ -1,0 +1,85 @@
+package com.aliucord.utils
+
+import com.google.gson.TypeAdapter
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonWriter
+import java.lang.IllegalArgumentException
+
+/**
+ * Parses a Semantic version in the format of `v1.0.0`
+ */
+@JsonAdapter(SemVer.Adapter::class)
+data class SemVer(
+    val major: Int,
+    val minor: Int,
+    val patch: Int,
+) : Comparable<SemVer> {
+    override fun compareTo(other: SemVer): Int {
+        val pairs = arrayOf(
+            major to other.major,
+            minor to other.minor,
+            patch to other.patch,
+        )
+
+        return pairs
+            .map { (first, second) -> first.compareTo(second) }
+            .find { it != 0 }
+            ?: 0
+    }
+
+    override fun equals(other: Any?): Boolean {
+        val ver = other as? SemVer
+            ?: return false
+
+        return ver.major == major &&
+            ver.minor == minor &&
+            ver.patch == patch
+    }
+
+    override fun toString(): String {
+        return "$major.$minor.$patch"
+    }
+
+    override fun hashCode(): Int {
+        var result = major
+        result = 31 * result + minor
+        result = 31 * result + patch
+        return result
+    }
+
+    companion object {
+        @JvmField
+        val Zero = SemVer(0, 0, 0)
+
+        @JvmStatic
+        fun parseOrNull(version: String?): SemVer? {
+            // Handle 'v' prefix
+            val versionString = version?.removePrefix("v")
+                ?: return null
+
+            val parts = versionString
+                .split(".")
+                .mapNotNull { it.toIntOrNull() }
+                .takeIf { it.size == 3 }
+                ?: return null
+
+            return SemVer(parts[0], parts[1], parts[2])
+        }
+
+        @JvmStatic
+        fun parse(version: String): SemVer = parseOrNull(version)
+            ?: throw IllegalArgumentException("Invalid semver string $version")
+    }
+
+    class Adapter : TypeAdapter<SemVer>() {
+        override fun read(input: JsonReader): SemVer {
+            val string = input.J() // nextString()
+            return parse(string)
+        }
+
+        override fun write(output: JsonWriter, value: SemVer) {
+            val string = value.toString()
+            output.H(string) // encode string
+        }
+    }
+}


### PR DESCRIPTION
Manager injects a config file into the APK with the versions of builds that were used to patch & install the APK. This parses and exposes that data.
