### PR TITLE
fix(UploadSize): lower non-nitro upload limit

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/UploadSize.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/UploadSize.kt
@@ -35,7 +35,7 @@ internal class UploadSize : CorePlugin(Manifest("UploadSize")) {
 
     @Suppress("PropertyName", "unused")
     private companion object {
-        const val DEFAULT_MAX_FILE_SIZE = 25
+        const val DEFAULT_MAX_FILE_SIZE = 10
         var id = 1
 
         class InitAttachmentUpload(val files: Array<File>) {


### PR DESCRIPTION
Adjusts upload limit for non-nitro users since Discord lowered it to 10 MB.