### PR TITLE
fix: crash due to bad apng stickers

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/PluginManager.java
+++ b/Aliucord/src/main/java/com/aliucord/PluginManager.java
@@ -253,6 +253,7 @@ public class PluginManager {
             new PrivateThreads(),
             new RNAPI(),
             new Pronouns(),
+            new StickerCrashFix(),
             new SupportWarn(),
             new SupporterBadges(),
             new TokenLogin(),

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/StickerCrashFix.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/StickerCrashFix.kt
@@ -1,0 +1,29 @@
+package com.aliucord.coreplugins
+
+import android.content.Context
+import com.aliucord.entities.CorePlugin
+import com.aliucord.patcher.before
+import com.linecorp.apng.decoder.Apng
+
+internal class StickerCrashFix : CorePlugin(Manifest("StickerCrashFix")) {
+    override val isHidden = true
+    override val isRequired = true
+
+    override fun load(context: Context) {
+        patcher.before<Apng>(
+            Integer::class.javaPrimitiveType!!,
+            Integer::class.javaPrimitiveType!!,
+            Integer::class.javaPrimitiveType!!,
+            Integer::class.javaPrimitiveType!!,
+            IntArray::class.java,
+            Integer::class.javaPrimitiveType!!,
+            Long::class.javaPrimitiveType!!,
+        ) { param ->
+            val durations = param.args[4] as IntArray
+            param.args[4] = durations.map { it.coerceAtLeast(100) }.toIntArray()
+        }
+    }
+
+    override fun start(context: Context) {}
+    override fun stop(context: Context) {}
+}


### PR DESCRIPTION
Discord stickers (including the cursed pineapple pizza sticker) may not set APNG delay properly. The official spec specifies some defaults, and in addition to some legacy web issues, the de-facto minimum delay is 100ms, as also seen on desktop Discord.

Without this, a division-by-zero occurs, and the app crashes when rendering such stickers.

ref: https://github.com/davidmz/apng-js/blob/52f6fab62ffabe2abac3467d6abf82fe98ba4018/src/library/parser.js#L62-L73