### PR TITLE
fix(StickerCrashFix): fix some stickers being slowed down

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/StickerCrashFix.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/StickerCrashFix.kt
@@ -20,7 +20,9 @@ internal class StickerCrashFix : CorePlugin(Manifest("StickerCrashFix")) {
             Long::class.javaPrimitiveType!!,
         ) { param ->
             val durations = param.args[4] as IntArray
-            param.args[4] = durations.map { if (it <= 10) 100 else it }.toIntArray()
+            for ((index, duration) in durations.withIndex())
+                if (duration <= 10)
+                    durations[index] = 100
         }
     }
 

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/StickerCrashFix.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/StickerCrashFix.kt
@@ -20,7 +20,7 @@ internal class StickerCrashFix : CorePlugin(Manifest("StickerCrashFix")) {
             Long::class.javaPrimitiveType!!,
         ) { param ->
             val durations = param.args[4] as IntArray
-            param.args[4] = durations.map { it.coerceAtLeast(100) }.toIntArray()
+            param.args[4] = durations.map { if (it <= 10) 100 else it }.toIntArray()
         }
     }
 


### PR DESCRIPTION
Only set delay to 100 if it is lesser than or equal to 10, which is apparently what most web browsers do.