### PR TITLE
fix(PluginDownloader): ensure new plugins are started

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/plugindownloader/PluginFile.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/plugindownloader/PluginFile.kt
@@ -33,7 +33,10 @@ internal class PluginFile(val plugin: String) : File("${Constants.PLUGINS_PATH}/
                         PluginManager.unloadPlugin(plugin)
                     }
                     PluginManager.loadPlugin(Utils.appContext, this)
-                    PluginManager.enablePlugin(plugin)
+                    if (PluginManager.isPluginEnabled(plugin))
+                        PluginManager.startPlugin(plugin)
+                    else
+                        PluginManager.enablePlugin(plugin)
                     Utils.showToast("Plugin $plugin successfully ${if (isReinstall) "re" else ""}installed!")
 
                     if (PluginManager.plugins[plugin]?.requiresRestart() == true)


### PR DESCRIPTION
#520 introduced a regression where plugins in most cases will not start upon installation. This is because `PluginManager.enablePlugin` skips plugin starting if the plugin is already enabled (which it usually is).

This PR fixes it by ensuring that new, enabled plugins are always started.