### PR TITLE
refactor: disable i18n project wide

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/Main.java
+++ b/Aliucord/src/main/java/com/aliucord/Main.java
@@ -7,7 +7,6 @@
 package com.aliucord;
 
 import android.Manifest;
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -127,7 +126,6 @@ public final class Main {
      * Aliucord's init hook. Plugins are started here
      * @noinspection unused
      */
-    @SuppressLint("SetTextI18n")
     public static void init(AppActivity activity) {
         if (initialized) return;
         initialized = true;

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/ForwardedMessages.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/ForwardedMessages.java
@@ -1,6 +1,5 @@
 package com.aliucord.coreplugins;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.view.View;
 import android.view.ViewGroup;
@@ -72,7 +71,6 @@ public class ForwardedMessages extends CorePlugin {
     }
 
     @Override
-    @SuppressLint("SetTextI18n")
     @SuppressWarnings("unchecked")
     public void start(Context context) throws Throwable {
         if (!ManagerBuild.hasInjector("2.1.0") || !ManagerBuild.hasPatches("1.1.0")) {

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/SupportWarn.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/SupportWarn.kt
@@ -1,6 +1,5 @@
 package com.aliucord.coreplugins
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
@@ -16,7 +15,6 @@ import com.discord.widgets.chat.input.ChatInputViewModel
 import com.discord.widgets.chat.input.WidgetChatInput
 import com.lytefast.flexinput.R
 
-@SuppressLint("SetTextI18n")
 internal class SupportWarn : CorePlugin(Manifest("SupportWarn")) {
     private val SettingsAPI.acceptedPrdNotRequests: Boolean by settings.delegate(false)
     private val SettingsAPI.acceptedDevNotSupport: Boolean by settings.delegate(false)

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/TokenLogin.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/TokenLogin.java
@@ -6,7 +6,6 @@
 
 package com.aliucord.coreplugins;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -78,7 +77,6 @@ public final class TokenLogin extends CorePlugin {
     }
 
     @Override
-    @SuppressLint("SetTextI18n")
     public void start(Context appContext) throws Throwable {
         Patcher.addPatch(WidgetAuthLanding.class.getDeclaredMethod("onViewBound", View.class), new Hook(param -> {
             Context context = ((WidgetAuthLanding) param.thisObject).requireContext();

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/UploadSize.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/UploadSize.kt
@@ -108,7 +108,6 @@ internal class UploadSize : CorePlugin(Manifest("UploadSize")) {
 
             XposedBridge.invokeOriginalMethod(it.method, it.thisObject, it.args)
 
-            @Suppress("SetTextI18n")
             g().j.text = "Max file size is $maxFileSize MB"
 
             null

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/forwardedmessages/WidgetChatListAdapterItemForwardSource.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/forwardedmessages/WidgetChatListAdapterItemForwardSource.kt
@@ -2,7 +2,6 @@
 
 package com.aliucord.coreplugins.forwardedmessages
 
-import android.annotation.SuppressLint
 import android.os.Build
 import android.text.Spannable
 import android.text.SpannableStringBuilder
@@ -58,7 +57,6 @@ internal class WidgetChatListAdapterItemForwardSource(
         /* color = */ 0
     ).mutate().also { it.setBounds(0, 0, 16.dp, 16.dp) }
 
-    @SuppressLint("SetTextI18n")
     override fun onConfigure(i: Int, data: ChatListEntry) {
         super.onConfigure(i, data)
         if (data !is ForwardSourceChatEntry) return

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/plugindownloader/Modal.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/plugindownloader/Modal.kt
@@ -6,7 +6,6 @@
 
 package com.aliucord.coreplugins.plugindownloader
 
-import android.annotation.SuppressLint
 import android.view.View
 import com.aliucord.fragments.SettingsPage
 import android.widget.TextView
@@ -27,7 +26,6 @@ internal class Modal(private val author: String, private val repo: String) : Set
     private var throwable = null as Throwable?
     private var plugins = null as Map<String, PluginInfo>?
 
-    @SuppressLint("SetTextI18n")
     override fun onViewBound(view: View) {
         super.onViewBound(view)
 

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/plugindownloader/PluginDownloader.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/plugindownloader/PluginDownloader.kt
@@ -6,7 +6,6 @@
 
 package com.aliucord.coreplugins.plugindownloader
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
@@ -47,7 +46,6 @@ internal class PluginDownloader : CorePlugin(Manifest("PluginDownloader")) {
         }
     }
 
-    @SuppressLint("SetTextI18n")
     override fun start(context: Context) {
         patcher.patch(
             WidgetChatListActions::class.java.getDeclaredMethod("configureUI", WidgetChatListActions.Model::class.java),

--- a/Aliucord/src/main/java/com/aliucord/fragments/InputDialog.java
+++ b/Aliucord/src/main/java/com/aliucord/fragments/InputDialog.java
@@ -7,7 +7,6 @@ package com.aliucord.fragments;
 
 import static android.view.View.OnClickListener;
 
-import android.annotation.SuppressLint;
 import android.text.method.LinkMovementMethod;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -43,7 +42,6 @@ public class InputDialog extends AppDialog {
     private View.OnClickListener onOkListener;
     private Integer inputType;
 
-    @SuppressLint("SetTextI18n")
     @Override
     public void onViewBound(View view) {
         super.onViewBound(view);

--- a/Aliucord/src/main/java/com/aliucord/settings/AliucordPage.kt
+++ b/Aliucord/src/main/java/com/aliucord/settings/AliucordPage.kt
@@ -6,7 +6,6 @@
 
 package com.aliucord.settings
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.view.View
 import android.widget.TextView
@@ -25,7 +24,6 @@ const val AUTO_UPDATE_ALIUCORD_KEY = "AC_aliucord_auto_update_enabled"
 const val ALIUCORD_FROM_STORAGE_KEY = "AC_from_storage"
 
 class AliucordPage : SettingsPage() {
-    @SuppressLint("SetTextI18n")
     override fun onViewBound(view: View) {
         super.onViewBound(view)
 

--- a/Aliucord/src/main/java/com/aliucord/settings/Crashes.kt
+++ b/Aliucord/src/main/java/com/aliucord/settings/Crashes.kt
@@ -5,7 +5,6 @@
  */
 package com.aliucord.settings
 
-import android.annotation.SuppressLint
 import android.text.SpannableStringBuilder
 import android.view.Gravity
 import android.view.View
@@ -26,7 +25,6 @@ import java.util.*
 private data class CrashLog(val timestamp: String, val stacktrace: String, var times: Int)
 
 class Crashes : SettingsPage() {
-    @SuppressLint("SetTextI18n")
     override fun onViewBound(view: View) {
         super.onViewBound(view)
         setActionBarTitle("Crash Logs")

--- a/Aliucord/src/main/java/com/aliucord/settings/Plugins.java
+++ b/Aliucord/src/main/java/com/aliucord/settings/Plugins.java
@@ -6,7 +6,6 @@
 
 package com.aliucord.settings;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.ShapeDrawable;
@@ -45,7 +44,6 @@ public class Plugins extends SettingsPage {
             private final Adapter adapter;
             public final PluginCard card;
 
-            @SuppressLint("SetTextI18n")
             public ViewHolder(Adapter adapter, PluginCard card) {
                 super(card);
                 this.adapter = adapter;
@@ -282,7 +280,6 @@ public class Plugins extends SettingsPage {
     }
 
     @Override
-    @SuppressLint("SetTextI18n")
     public void onViewBound(View view) {
         super.onViewBound(view);
         setActionBarTitle("Plugins");

--- a/Aliucord/src/main/java/com/aliucord/settings/Updater.java
+++ b/Aliucord/src/main/java/com/aliucord/settings/Updater.java
@@ -11,7 +11,6 @@ import static com.aliucord.updater.Updater.isDiscordOutdated;
 import static com.aliucord.updater.Updater.updateAliucord;
 import static com.aliucord.updater.Updater.usingDexFromStorage;
 
-import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.graphics.Color;
 import android.view.Gravity;
@@ -31,7 +30,6 @@ public class Updater extends SettingsPage {
     private String stateText = "No new updates found";
 
     @Override
-    @SuppressLint("SetTextI18n")
     public void onViewBound(View view) {
         super.onViewBound(view);
 

--- a/Aliucord/src/main/java/com/aliucord/widgets/FailedPluginWidget.kt
+++ b/Aliucord/src/main/java/com/aliucord/widgets/FailedPluginWidget.kt
@@ -22,7 +22,7 @@ import com.discord.utilities.file.FileUtilsKt
 import com.lytefast.flexinput.R
 import java.io.File
 
-@SuppressLint("SetTextI18n", "ViewConstructor")
+@SuppressLint("ViewConstructor")
 class FailedPluginWidget(ctx: Context, private val file: File, private val reason: Any, onDelete: () -> Unit) : LinearLayout(ctx),
     View.OnClickListener {
     private val shortReason = reason.toString().let { if (reason is Throwable) "$it\n\n(Click file name for full info)" else it }

--- a/Aliucord/src/main/java/com/aliucord/widgets/PluginCard.java
+++ b/Aliucord/src/main/java/com/aliucord/widgets/PluginCard.java
@@ -6,7 +6,6 @@
 
 package com.aliucord.widgets;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.text.method.LinkMovementMethod;
 import android.view.Gravity;
@@ -36,7 +35,6 @@ public class PluginCard extends MaterialCardView {
     public final ToolbarButton repoButton;
     public final ToolbarButton changeLogButton;
 
-    @SuppressLint("SetTextI18n")
     public PluginCard(Context ctx) {
         super(ctx);
         setRadius(DimenUtils.getDefaultCardRadius());

--- a/Aliucord/src/main/java/com/aliucord/widgets/UpdaterPluginCard.java
+++ b/Aliucord/src/main/java/com/aliucord/widgets/UpdaterPluginCard.java
@@ -28,7 +28,7 @@ import com.discord.utilities.color.ColorCompat;
 import com.google.android.material.card.MaterialCardView;
 import com.lytefast.flexinput.R;
 
-@SuppressLint({"SetTextI18n", "ViewConstructor"})
+@SuppressLint({"ViewConstructor"})
 public class UpdaterPluginCard extends MaterialCardView {
     public UpdaterPluginCard(Context context, String plugin, Runnable forceUpdate) {
         super(context);

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,10 @@ subprojects {
             targetSdk = 30
         }
 
+        lintOptions {
+            disable += "SetTextI18n"
+        }
+
         buildTypes {
             get("release").isMinifyEnabled = false
         }


### PR DESCRIPTION
Disables i18n for the entire Aliucord project. This is much better than the `@SuppressLint("SetTextI18n")` spam that's everywhere.