### PR TITLE
fix: separate original and custom core bundles

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/settings/AliucordPage.kt
+++ b/Aliucord/src/main/java/com/aliucord/settings/AliucordPage.kt
@@ -48,9 +48,12 @@ class AliucordPage : SettingsPage() {
             addSwitch(
                 ctx,
                 ALIUCORD_FROM_STORAGE_KEY,
-                "Use Aliucord from storage",
-                "Meant for developers. Do not enable unless you know what you're doing. If someone else is telling you to do this, you are likely being scammed."
-            )
+                "Use Aliucord core from storage",
+                "Meant for developers. Do not enable unless you know what you're doing. " +
+                    "Uses a custom core bundle that was pushed to the device.",
+            ) {
+                Utils.promptRestart()
+            }
         }
 
         addDivider(ctx)
@@ -66,11 +69,19 @@ class AliucordPage : SettingsPage() {
         }
     }
 
-    private fun addSwitch(ctx: Context, setting: String, title: String, subtitle: String?, default: Boolean = false) {
+    private fun addSwitch(
+        ctx: Context,
+        setting: String,
+        title: String,
+        subtitle: String?,
+        default: Boolean = false,
+        onToggled: ((checked: Boolean) -> Unit)? = null,
+    ) {
         Utils.createCheckedSetting(ctx, CheckedSetting.ViewType.SWITCH, title, subtitle).run {
             isChecked = Main.settings.getBool(setting, default)
             setOnCheckedListener {
                 Main.settings.setBool(setting, it)
+                onToggled?.invoke(it)
             }
             linearLayout.addView(this)
         }

--- a/Injector/src/main/java/com/aliucord/injector/Injector.kt
+++ b/Injector/src/main/java/com/aliucord/injector/Injector.kt
@@ -129,7 +129,8 @@ private fun init(appActivity: AppActivity) {
 }
 
 /**
- * Checks if app has permission for storage and if so checks settings and copies local dex to internal caches.
+ * Checks if app has permission for storage and if so checks settings as to whether
+ * using custom/local core bundle is enable .
  */
 private fun useCustomDex(appActivity: AppActivity): Boolean {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {

--- a/Injector/src/main/java/com/aliucord/injector/Injector.kt
+++ b/Injector/src/main/java/com/aliucord/injector/Injector.kt
@@ -72,6 +72,11 @@ private fun init(appActivity: AppActivity) {
         val customDexFile = appActivity.codeCacheDir.resolve("Aliucord.custom.zip")
         val useCustomDex = useCustomDex(appActivity)
 
+        // Copy core bundle from external storage to internal cache
+        if (useCustomDex) {
+            File(BASE_DIRECTORY, "Aliucord.zip").copyTo(customDexFile, overwrite = true)
+        }
+
         // Download new core
         if (!useCustomDex && !dexFile.exists()) {
             val successRef = AtomicBoolean(true)

--- a/Injector/src/main/java/com/aliucord/injector/Injector.kt
+++ b/Injector/src/main/java/com/aliucord/injector/Injector.kt
@@ -68,9 +68,12 @@ private fun init(appActivity: AppActivity) {
     Logger.d("Initializing Aliucord...")
 
     try {
-        val dexFile = File(appActivity.codeCacheDir, "Aliucord.zip")
+        val dexFile = appActivity.codeCacheDir.resolve("Aliucord.zip")
+        val customDexFile = appActivity.codeCacheDir.resolve("Aliucord.custom.zip")
+        val useCustomDex = useCustomDex(appActivity)
 
-        if (!useLocalDex(appActivity, dexFile) && !dexFile.exists()) {
+        // Download new core
+        if (!useCustomDex && !dexFile.exists()) {
             val successRef = AtomicBoolean(true)
             Thread {
                 try {
@@ -106,7 +109,7 @@ private fun init(appActivity: AppActivity) {
         }
 
         Logger.d("Adding Aliucord to the classpath...")
-        addDexToClasspath(dexFile, appActivity.classLoader)
+        addDexToClasspath(if (useCustomDex) customDexFile else dexFile, appActivity.classLoader)
         val c = Class.forName("com.aliucord.Main")
         val preInit = c.getDeclaredMethod("preInit", AppActivity::class.java)
         val init = c.getDeclaredMethod("init", AppActivity::class.java)
@@ -126,9 +129,9 @@ private fun init(appActivity: AppActivity) {
 }
 
 /**
- * Checks if app has permission for storage and if so checks settings and copies local dex to code cache
+ * Checks if app has permission for storage and if so checks settings and copies local dex to internal caches.
  */
-private fun useLocalDex(appActivity: AppActivity, dexFile: File): Boolean {
+private fun useCustomDex(appActivity: AppActivity): Boolean {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
         if (!Environment.isExternalStorageManager())
             return false
@@ -145,7 +148,6 @@ private fun useLocalDex(appActivity: AppActivity, dexFile: File): Boolean {
     if (!useLocalDex) return false
 
     Logger.d("Loading dex from ${localDexFile.absolutePath}")
-    localDexFile.copyTo(dexFile, true)
     return true
 }
 


### PR DESCRIPTION
No longer copy the local/custom core bundle to the same place as the official core bundle. This makes switching much easier for users who are smart enough to enable it but then too dumb to know how to clear the cache afterwards.