### PR TITLE
feat(PluginDownloader): only allow plugin zips from trusted members in support channels

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/Constants.java
+++ b/Aliucord/src/main/java/com/aliucord/Constants.java
@@ -37,13 +37,15 @@ public final class Constants {
     /** Code of the Aliucord discord server */
     public static final String ALIUCORD_SUPPORT = "EsNDvBaHVU";
     public static final long ALIUCORD_GUILD_ID = 811255666990907402L;
-    public static final long SUPPORT_CHANNEL_ID = 811261298997460992L;
-    public static final long PLUGIN_SUPPORT_CHANNEL_ID = 847566769258233926L;
-    public static final long PLUGIN_LINKS_CHANNEL_ID = 811275162715553823L;
-    public static final long PLUGIN_LINKS_UPDATES_CHANNEL_ID = 845784407846813696L;
-    public static final long PLUGIN_REQUESTS_CHANNEL_ID = 811275334342541353L;
-    public static final long THEMES_CHANNEL_ID = 824357609778708580L;
-    public static final long PLUGIN_DEVELOPMENT_CHANNEL_ID = 811261478875299840L;
+    public static final long SUPPORT_CHANNEL_ID = 811261298997460992L; // #support
+    public static final long PLUGIN_SUPPORT_CHANNEL_ID = 847566769258233926L; // #plugin-support
+    public static final long PLUGIN_LINKS_CHANNEL_ID = 811275162715553823L; // #plugins-list
+    public static final long PLUGIN_LINKS_UPDATES_CHANNEL_ID = 845784407846813696L; // #new-plugins
+    public static final long PLUGIN_REQUESTS_CHANNEL_ID = 811275334342541353L; // #plugin-requests
+    public static final long THEMES_CHANNEL_ID = 824357609778708580L; // #themes
+    public static final long PLUGIN_DEVELOPMENT_CHANNEL_ID = 811261478875299840L; // #plugin-development
+    public static final long PLUGIN_DEVELOPER_ROLE_ID = 811277662747623464L; // @plugin-developer
+    public static final long SUPPORT_HELPER_ROLE_ID = 1397067198761144361L; // @support-helper
 
     /** Path of Aliucord folder */
     public static final String BASE_PATH = Environment.getExternalStorageDirectory().getAbsolutePath() + "/Aliucord";

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/plugindownloader/PluginDownloader.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/plugindownloader/PluginDownloader.kt
@@ -15,11 +15,10 @@ import com.aliucord.Constants.*
 import com.aliucord.Logger
 import com.aliucord.Utils
 import com.aliucord.entities.CorePlugin
-import com.aliucord.patcher.Hook
-import com.aliucord.patcher.component1
-import com.aliucord.patcher.component2
+import com.aliucord.patcher.*
 import com.aliucord.wrappers.messages.AttachmentWrapper.Companion.filename
 import com.aliucord.wrappers.messages.AttachmentWrapper.Companion.url
+import com.discord.stores.StoreStream
 import com.discord.utilities.color.ColorCompat
 import com.discord.widgets.chat.list.actions.WidgetChatListActions
 import com.lytefast.flexinput.R
@@ -72,26 +71,22 @@ internal class PluginDownloader : CorePlugin(Manifest("PluginDownloader")) {
                 }
 
                 when (msg.channelId) {
-                    PLUGIN_LINKS_UPDATES_CHANNEL_ID, PLUGIN_SUPPORT_CHANNEL_ID, PLUGIN_DEVELOPMENT_CHANNEL_ID -> {
-                        zipPattern.matcher(content).run {
-                            while (find()) {
-                                val author = group(1)!!
-                                val repo = group(2)!!
-                                val name = group(3)!!
-                                val plugin = PluginFile(name)
-                                addEntry(layout, "${if (plugin.isInstalled) "Reinstall" else "Install"} $name") {
-                                    plugin.install(author, repo)
-                                    actions.dismiss()
-                                }
-                            }
-                        }
+                    PLUGIN_LINKS_UPDATES_CHANNEL_ID, PLUGIN_DEVELOPMENT_CHANNEL_ID ->
+                        handlePluginZipMessage(content, layout, actions)
+
+                    SUPPORT_CHANNEL_ID, PLUGIN_SUPPORT_CHANNEL_ID -> {
+                        val member = StoreStream.getGuilds().getMember(ALIUCORD_GUILD_ID, msg.author.id)
+                        val isTrusted = member?.roles?.any { it in arrayOf(SUPPORT_HELPER_ROLE_ID, PLUGIN_DEVELOPER_ROLE_ID) } ?: false
+
+                        if (isTrusted) handlePluginZipMessage(content, layout, actions)
                     }
+
                     PLUGIN_LINKS_CHANNEL_ID -> {
                         repoPattern.matcher(content).takeIf { it.find() }?.run {
                             val author = group(1)!!
                             val repo = group(2)!!
 
-                            addEntry(layout, "Open PluginDownloader") {
+                            addEntry(layout, "Open Plugin Downloader") {
                                 Utils.openPageWithProxy(it.context, Modal(author, repo))
                                 actions.dismiss()
                             }
@@ -103,6 +98,22 @@ internal class PluginDownloader : CorePlugin(Manifest("PluginDownloader")) {
     }
 
     override fun stop(context: Context) {}
+
+    private fun handlePluginZipMessage(content: String, layout: ViewGroup, actions: WidgetChatListActions) {
+        zipPattern.matcher(content).run {
+            while (find()) {
+                val author = group(1)!!
+                val repo = group(2)!!
+                val name = group(3)!!
+
+                val plugin = PluginFile(name)
+                addEntry(layout, "${if (plugin.isInstalled) "Reinstall" else "Install"} $name") {
+                    plugin.install(author, repo)
+                    actions.dismiss()
+                }
+            }
+        }
+    }
 
     private fun addEntry(layout: ViewGroup, text: String, onClick: View.OnClickListener) {
         val replyView =


### PR DESCRIPTION
Allows installing from plugin zip urls in #support (new) and #plugin-support, but only from members with either of the following roles:
- `@support-helper`
- `@plugin-developer`

Supersedes #562