### PR TITLE
feat: stop crashlytics folder from being made on startup

### DIFF
--- a/patches/src/b/i/c/m/d/o/h.patch
+++ b/patches/src/b/i/c/m/d/o/h.patch
@@ -1,6 +1,6 @@
 --- smali_original/b/i/c/m/d/o/h.smali
 +++ smali/b/i/c/m/d/o/h.smali
-@@ -26,41 +26,9 @@ .method public a()Ljava/io/File;
+@@ -26,44 +26,7 @@ .method public a()Ljava/io/File;
      .locals 3
  
      .line 1
@@ -32,13 +32,16 @@
 -    goto :goto_22
 -
 -    .line 3
-     :cond_1a
-     sget-object v0, Lb/i/c/m/d/b;->a:Lb/i/c/m/d/b;
- 
+-    :cond_1a
+-    sget-object v0, Lb/i/c/m/d/b;->a:Lb/i/c/m/d/b;
+-
 -    const-string v1, "Couldn\'t create file"
 -
 -    invoke-virtual {v0, v1}, Lb/i/c/m/d/b;->g(Ljava/lang/String;)V
 -
      const/4 v0, 0x0
  
-     :cond_22
+-    :cond_22
+-    :goto_22
+     return-object v0
+ .end method

--- a/patches/src/b/i/c/m/d/o/h.patch
+++ b/patches/src/b/i/c/m/d/o/h.patch
@@ -1,6 +1,6 @@
 --- smali_original/b/i/c/m/d/o/h.smali
 +++ smali/b/i/c/m/d/o/h.smali
-@@ -26,34 +26,6 @@ .method public a()Ljava/io/File;
+@@ -26,41 +26,9 @@ .method public a()Ljava/io/File;
      .locals 3
  
      .line 1
@@ -35,3 +35,10 @@
      :cond_1a
      sget-object v0, Lb/i/c/m/d/b;->a:Lb/i/c/m/d/b;
  
+-    const-string v1, "Couldn\'t create file"
+-
+-    invoke-virtual {v0, v1}, Lb/i/c/m/d/b;->g(Ljava/lang/String;)V
+-
+     const/4 v0, 0x0
+ 
+     :cond_22

--- a/patches/src/b/i/c/m/d/o/h.patch
+++ b/patches/src/b/i/c/m/d/o/h.patch
@@ -1,0 +1,37 @@
+--- smali_original/b/i/c/m/d/o/h.smali
++++ smali/b/i/c/m/d/o/h.smali
+@@ -26,34 +26,6 @@ .method public a()Ljava/io/File;
+     .locals 3
+ 
+     .line 1
+-    new-instance v0, Ljava/io/File;
+-
+-    iget-object v1, p0, Lb/i/c/m/d/o/h;->a:Landroid/content/Context;
+-
+-    invoke-virtual {v1}, Landroid/content/Context;->getFilesDir()Ljava/io/File;
+-
+-    move-result-object v1
+-
+-    const-string v2, ".com.google.firebase.crashlytics"
+-
+-    invoke-direct {v0, v1, v2}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
+-
+-    .line 2
+-    invoke-virtual {v0}, Ljava/io/File;->exists()Z
+-
+-    move-result v1
+-
+-    if-nez v1, :cond_22
+-
+-    invoke-virtual {v0}, Ljava/io/File;->mkdirs()Z
+-
+-    move-result v1
+-
+-    if-eqz v1, :cond_1a
+-
+-    goto :goto_22
+-
+-    .line 3
+     :cond_1a
+     sget-object v0, Lb/i/c/m/d/b;->a:Lb/i/c/m/d/b;
+ 

--- a/patches/src/b/i/c/m/e/b.patch
+++ b/patches/src/b/i/c/m/e/b.patch
@@ -1,0 +1,25 @@
+--- smali_original/b/i/c/m/e/b.smali
++++ smali/b/i/c/m/e/b.smali
+@@ -41,16 +41,16 @@ .method public a(Lb/i/c/l/e;)Ljava/lang/
+     check-cast p1, Landroid/content/Context;
+ 
+     .line 3
+-    new-instance v0, Ljava/io/File;
+-
+-    invoke-virtual {p1}, Landroid/content/Context;->getFilesDir()Ljava/io/File;
++    :cond_1a
++    sget-object v0, Lb/i/c/m/d/b;->a:Lb/i/c/m/d/b;
+ 
+-    move-result-object v1
++    const-string v1, "Couldn\'t create file"
+ 
+-    const-string v2, ".com.google.firebase.crashlytics-ndk"
++    invoke-virtual {v0, v1}, Lb/i/c/m/d/b;->g(Ljava/lang/String;)V
+ 
+-    invoke-direct {v0, v1, v2}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
++    const/4 v0, 0x0
+ 
++    return-object v0
+     .line 4
+     new-instance v1, Lb/i/c/m/e/a;
+ 

--- a/patches/src/b/i/c/m/e/b.patch
+++ b/patches/src/b/i/c/m/e/b.patch
@@ -1,20 +1,18 @@
 --- smali_original/b/i/c/m/e/b.smali
 +++ smali/b/i/c/m/e/b.smali
-@@ -41,16 +41,16 @@ .method public a(Lb/i/c/l/e;)Ljava/lang/
+@@ -41,16 +41,12 @@ .method public a(Lb/i/c/l/e;)Ljava/lang/
      check-cast p1, Landroid/content/Context;
  
      .line 3
 -    new-instance v0, Ljava/io/File;
 -
 -    invoke-virtual {p1}, Landroid/content/Context;->getFilesDir()Ljava/io/File;
+-
+-    move-result-object v1
+-
+-    const-string v2, ".com.google.firebase.crashlytics-ndk"
 +    :cond_1a
 +    sget-object v0, Lb/i/c/m/d/b;->a:Lb/i/c/m/d/b;
- 
--    move-result-object v1
-+    const-string v1, "Couldn\'t create file"
- 
--    const-string v2, ".com.google.firebase.crashlytics-ndk"
-+    invoke-virtual {v0, v1}, Lb/i/c/m/d/b;->g(Ljava/lang/String;)V
  
 -    invoke-direct {v0, v1, v2}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
 +    const/4 v0, 0x0

--- a/patches/src/b/i/c/m/e/b.patch
+++ b/patches/src/b/i/c/m/e/b.patch
@@ -1,6 +1,6 @@
 --- smali_original/b/i/c/m/e/b.smali
 +++ smali/b/i/c/m/e/b.smali
-@@ -41,16 +41,12 @@ .method public a(Lb/i/c/l/e;)Ljava/lang/
+@@ -41,15 +41,9 @@ .method public a(Lb/i/c/l/e;)Ljava/lang/
      check-cast p1, Landroid/content/Context;
  
      .line 3
@@ -11,13 +11,10 @@
 -    move-result-object v1
 -
 -    const-string v2, ".com.google.firebase.crashlytics-ndk"
-+    :cond_1a
-+    sget-object v0, Lb/i/c/m/d/b;->a:Lb/i/c/m/d/b;
- 
--    invoke-direct {v0, v1, v2}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
 +    const/4 v0, 0x0
  
+-    invoke-direct {v0, v1, v2}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
 +    return-object v0
+ 
      .line 4
      new-instance v1, Lb/i/c/m/e/a;
- 


### PR DESCRIPTION
i made smali patches which stops  `.com.google.firebase.crashlytics` and `.com.google.firebase.crashlytics-ndk` from being made so they don't add an additional 16kB on startup which overtime can increase the user data size by alot