### PR TITLE
fix: fix dialogs not showing up

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/Main.java
+++ b/Aliucord/src/main/java/com/aliucord/Main.java
@@ -311,9 +311,9 @@ public final class Main {
 
         // Disable the Discord changelog page
         Patcher.addPatch(StoreChangeLog.class,
-            "openChangeLog",
-            new Class[]{ Context.class, boolean.class },
-            new InsteadHook(param -> null)
+            "shouldShowChangelog",
+            new Class[]{ Context.class, long.class, String.class, Integer.class },
+            new InsteadHook(param -> false)
         );
 
         // Disable the google play rating request dialog


### PR DESCRIPTION
The changelog patch in https://github.com/Aliucord/Aliucord/commit/c4c118fc5a0fd373121081270226cfe0fd5ce6d1 prevented the dialog from showing up, but it would already be queued, blocking any other dialogs from showing up such as the suspicious links dialog.

This PR patches `shouldShowChangelog()` instead, which would stop the whole changelog process from happening.