### PR TITLE
feat(CorePlugins): add AlignThreads fix

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/PluginManager.kt
+++ b/Aliucord/src/main/java/com/aliucord/PluginManager.kt
@@ -291,6 +291,7 @@ object PluginManager {
             SupporterBadges(),
             TokenLogin(),
             UploadSize(),
+            AlignThreads()
         )
 
         corePlugins.forEach { p ->

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/AlignThreads.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/AlignThreads.kt
@@ -41,7 +41,7 @@ internal class AlignThreads : CorePlugin(Manifest("AlignThreads")) {
         val iconId = if (themed) {
             DrawableCompat.getThemedDrawableRes(rootView.context, R.b.ic_thread)
         } else {
-            R.b.ic_thread
+            R.e.ic_thread
         }
         val icon = ContextCompat.getDrawable(rootView.context, iconId)!!.apply {
             val size = DimenUtils.dpToPx(24)

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/AlignThreads.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/AlignThreads.kt
@@ -5,7 +5,6 @@ import android.view.View
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import com.aliucord.Utils
-import com.aliucord.annotations.AliucordPlugin
 import com.aliucord.entities.CorePlugin
 import com.aliucord.patcher.*
 import com.aliucord.utils.DimenUtils
@@ -20,20 +19,36 @@ internal class AlignThreads : CorePlugin(Manifest("AlignThreads")) {
     }
 
     override fun start(context: Context) {
-        patcher.after<`WidgetChannelsListItemChannelActions$binding$2`>("invoke", View::class.java) { (_, view: View) -> adjustIcon(view, true, true) }
-        patcher.after<`WidgetChatListActions$binding$2`>("invoke", View::class.java) { (_, view: View) -> adjustIcon(view, false, false) }
-    }
-
-    private fun adjustIcon(view: View, res_id: Boolean, res: Boolean) {
-        val res_id = if (res_id) "text_action_thread_browser" else "dialog_chat_actions_start_thread"
-        val id = Utils.getResId(res_id, "id")
-        val textview = view.findViewById<TextView>(id)
-        val size = DimenUtils.dpToPx(24)
-        val res = if (res) DrawableCompat.getThemedDrawableRes(textview.context, R.b.ic_thread) else R.e.ic_thread
-        val icon = ContextCompat.getDrawable(textview.context, res)!!
-        icon.setBounds(0, 0, size, size)
-        textview.setCompoundDrawables(icon, null, null, null)
+        patcher.after<`WidgetChannelsListItemChannelActions$binding$2`>("invoke", View::class.java) { (_, view: View) ->
+            adjustThreadIcon(
+                rootView = view,
+                textViewId = Utils.getResId("text_action_thread_browser", "id"),
+                themed = true,
+            )
+        }
+        patcher.after<`WidgetChatListActions$binding$2`>("invoke", View::class.java) { (_, view: View) ->
+            adjustThreadIcon(
+                rootView = view,
+                textViewId = Utils.getResId("dialog_chat_actions_start_thread", "id"),
+                themed = false,
+            )
+        }
     }
 
     override fun stop(context: Context) = patcher.unpatchAll()
+
+    private fun adjustThreadIcon(rootView: View, textViewId: Int, themed: Boolean) {
+        val iconId = if (themed) {
+            DrawableCompat.getThemedDrawableRes(rootView.context, R.b.ic_thread)
+        } else {
+            R.b.ic_thread
+        }
+        val icon = ContextCompat.getDrawable(rootView.context, iconId)!!.apply {
+            val size = DimenUtils.dpToPx(24)
+            setBounds(0, 0, size, size)
+        }
+
+        val textView = rootView.findViewById<TextView>(textViewId)
+        textView.setCompoundDrawables(icon, null, null, null)
+    }
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/AlignThreads.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/AlignThreads.kt
@@ -1,0 +1,39 @@
+package com.aliucord.coreplugins
+
+import android.content.Context
+import android.view.View
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import com.aliucord.Utils
+import com.aliucord.annotations.AliucordPlugin
+import com.aliucord.entities.CorePlugin
+import com.aliucord.patcher.*
+import com.aliucord.utils.DimenUtils
+import com.discord.utilities.drawable.DrawableCompat
+import com.discord.widgets.channels.list.`WidgetChannelsListItemChannelActions$binding$2`
+import com.discord.widgets.chat.list.actions.`WidgetChatListActions$binding$2`
+import com.lytefast.flexinput.R
+
+internal class AlignThreads : CorePlugin(Manifest("AlignThreads")) {
+    init {
+        manifest.description = "Adjusts the Threads icon in the Chat actions menu"
+    }
+
+    override fun start(context: Context) {
+        patcher.after<`WidgetChannelsListItemChannelActions$binding$2`>("invoke", View::class.java) { (_, view: View) -> adjustIcon(view, true, true) }
+        patcher.after<`WidgetChatListActions$binding$2`>("invoke", View::class.java) { (_, view: View) -> adjustIcon(view, false, false) }
+    }
+
+    private fun adjustIcon(view: View, res_id: Boolean, res: Boolean) {
+        val res_id = if (res_id) "text_action_thread_browser" else "dialog_chat_actions_start_thread"
+        val id = Utils.getResId(res_id, "id")
+        val textview = view.findViewById<TextView>(id)
+        val size = DimenUtils.dpToPx(24)
+        val res = if (res) DrawableCompat.getThemedDrawableRes(textview.context, R.b.ic_thread) else R.e.ic_thread
+        val icon = ContextCompat.getDrawable(textview.context, res)!!
+        icon.setBounds(0, 0, size, size)
+        textview.setCompoundDrawables(icon, null, null, null)
+    }
+
+    override fun stop(context: Context) = patcher.unpatchAll()
+}


### PR DESCRIPTION
i changed the threads icon from 20dp to 24dp in the chat actions menu/channel actions so it doesn't look off between the rest of the icons which are 24dp