### PR TITLE
feat(patches): handle unknown new reply message types

### DIFF
--- a/patches/src/com/discord/widgets/chat/list/adapter/WidgetChatListAdapterItemMessage.patch
+++ b/patches/src/com/discord/widgets/chat/list/adapter/WidgetChatListAdapterItemMessage.patch
@@ -1,0 +1,11 @@
+--- smali_original/com/discord/widgets/chat/list/adapter/WidgetChatListAdapterItemMessage.smali
++++ smali/com/discord/widgets/chat/list/adapter/WidgetChatListAdapterItemMessage.smali
+@@ -1967,8 +1967,6 @@ .method private final configureReplyPrev
+ 
+     invoke-static/range {v1 .. v6}, Lcom/discord/utilities/logging/Logger;->e$default(Lcom/discord/utilities/logging/Logger;Ljava/lang/String;Ljava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)V
+ 
+-    goto :goto_171
+-
+     :cond_120
+     :goto_120
+     const p1, 0x7f1221f6


### PR DESCRIPTION
Every time discord adds a new message construct, `WidgetChatListAdapterItemMessage.configureReplyPreview` will die on it with an unhandled reply preview error (and display text from a random preview instead) because it expects the message to satisfy at least one of the conditions.
This patch makes it default to the generic `Tap to see attachment` text instead of exploding.