### PR TITLE
feat(Patches): add `.gif` sticker format

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/rn/Patches.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/rn/Patches.kt
@@ -242,6 +242,11 @@ fun patchStickers() {
     }
     Patcher.addPatch(Sticker::class.java.getDeclaredMethod("a"), hook)
     Patcher.addPatch(StickerPartial::class.java.getDeclaredMethod("a"), hook)
+    val hook2 = Hook {
+        if (it.result == "") it.result = ".gif"
+    }
+    Patcher.addPatch(Sticker::class.java.getDeclaredMethod("b"), hook2)
+    Patcher.addPatch(StickerPartial::class.java.getDeclaredMethod("b"), hook2)
 }
 
 fun patchVoice() {


### PR DESCRIPTION
Smali patching in GIF formatType breaks things that work fine with current `Patches.kt`, and the only feature that's actually missing is the ability to send links to gif stickers, so I patched the fallback `""` format extension to be `".gif"` instead since there is no more sticker types anyway.