### PR TITLE
fix(PluginDownloader): duplicate install buttons in plugin development channel

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/plugindownloader/PluginDownloader.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/plugindownloader/PluginDownloader.kt
@@ -57,21 +57,8 @@ internal class PluginDownloader : CorePlugin(Manifest("PluginDownloader")) {
                 val msg = model.message
                 val content = msg?.content ?: return@Hook
 
-                if (msg.channelId == PLUGIN_DEVELOPMENT_CHANNEL_ID && msg.hasAttachments()) {
-                    msg.attachments.forEach { attachment ->
-                        val parts = attachment.filename.split('.')
-                        if (parts.size == 2 && parts[1] == "zip" && parts[0] != "Aliucord") {
-                            val plugin = PluginFile(parts[0])
-                            addEntry(layout, "${if (plugin.isInstalled) "Reinstall" else "Install"} ${plugin.name}") {
-                                plugin.install(attachment.url)
-                                actions.dismiss()
-                            }
-                        }
-                    }
-                }
-
                 when (msg.channelId) {
-                    PLUGIN_LINKS_UPDATES_CHANNEL_ID ->
+                    PLUGIN_LINKS_UPDATES_CHANNEL_ID, PLUGIN_DEVELOPMENT_CHANNEL_ID ->
                         handlePluginZipMessage(msg, layout, actions)
 
                     SUPPORT_CHANNEL_ID, PLUGIN_SUPPORT_CHANNEL_ID -> {

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/plugindownloader/PluginDownloader.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/plugindownloader/PluginDownloader.kt
@@ -71,7 +71,7 @@ internal class PluginDownloader : CorePlugin(Manifest("PluginDownloader")) {
                 }
 
                 when (msg.channelId) {
-                    PLUGIN_LINKS_UPDATES_CHANNEL_ID, PLUGIN_DEVELOPMENT_CHANNEL_ID ->
+                    PLUGIN_LINKS_UPDATES_CHANNEL_ID ->
                         handlePluginZipMessage(msg, layout, actions)
 
                     SUPPORT_CHANNEL_ID, PLUGIN_SUPPORT_CHANNEL_ID -> {


### PR DESCRIPTION
for some reason the code checks twice if a message has a plugin zip file so as a result, there would be 2 buttons which are "Install {plugin}" and "Install {plugin}.zip"..