### PR TITLE
feat: remove billing settings/nitro header

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/RemoveBilling.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/RemoveBilling.kt
@@ -31,9 +31,11 @@ internal class RemoveBilling : CorePlugin(Manifest("RemoveBilling")) {
         // Remove Billing settings
         patcher.after<WidgetSettings>("onViewBound", View::class.java) { (_, view: View) ->
             var container = view.findViewById<LinearLayout>(Utils.getResId("nitro_settings_container", "id"))
-            for (id in arrayOf("settings_nitro", "nitro_boosting")) {
+            for (id in arrayOf("settings_nitro", "nitro_boosting", "nitro_header")) {
                 container.removeView(view.findViewById(Utils.getResId(id, "id")))
             }
+            // Remove Billing settings divider
+            container.removeViewAt(0)
         }
 
         // Remove Gift button


### PR DESCRIPTION
for some reason, when tapping on the billing settings header it redirects to the nitro page which is what removebilling was meant to remove, it also makes a bit more clutter in the settings ui, this will also bring the nitro gifting button to user settings