### PR TITLE
feat(RemoveBilling): dont remove billing if user has nitro

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/RemoveBilling.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/RemoveBilling.kt
@@ -22,7 +22,7 @@ internal class RemoveBilling : CorePlugin(Manifest("RemoveBilling")) {
     override val isHidden = true
 
     init {
-        manifest.description = "Removes all references to billing and nitro (doesn't remove when the user has nitro)"
+        manifest.description = "Removes references to billing/nitro when user doesn't have nitro"
     }
 
     override fun start(context: Context) {


### PR DESCRIPTION
some functionalities still work for nitro users, like gifting, unsubscribing and cancelling their subscriptions, so why not enable billing for these users.. 