### PR TITLE
fix(OpenLinksExternallyFix): fix IllegalArgumentException

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/OpenLinksExternallyFix.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/OpenLinksExternallyFix.kt
@@ -29,8 +29,6 @@ internal class OpenLinksExternallyFix : CorePlugin(Manifest("OpenLinksExternally
 
         patcher.before<Activity>("startActivity", Intent::class.java) { param -> handleIntent(param) }
         patcher.before<Activity>("startActivityForResult", Intent::class.java, Int::class.javaPrimitiveType!!, Bundle::class.java) { param -> handleIntent(param) }
-        patcher.before<Context>("startActivity", Intent::class.java) { param -> handleIntent(param) }
-        patcher.before<Context>("startActivity", Intent::class.java, Bundle::class.java) { param -> handleIntent(param) }
     }
     override fun stop(context: Context) {}
 }


### PR DESCRIPTION
removes ``patcher.before<Context>``