### PR TITLE
feat(RemoveBilling): remove more upsells & cleanup

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/RemoveBilling.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/RemoveBilling.kt
@@ -98,7 +98,7 @@ internal class RemoveBilling : CorePlugin(Manifest("RemoveBilling")) {
 
         // Remove "Get Nitro" button when holding down on emojis
         val getBinding = WidgetEmojiSheet::class.java.getDeclaredMethod("getBinding")
-        getBinding.isAccessible = true
+            .apply { isAccessible = true }
 
         patcher.after<WidgetEmojiSheet>("configureButtons", Boolean::class.java, Boolean::class.java, Guild::class.java) { param ->
             val binding = getBinding.invoke(param.thisObject) as WidgetEmojiSheetBinding


### PR DESCRIPTION
this patches the get nitro button when holding down emojis aswell as the "learn about nitro" button when uploading a huge file which is more than 50mb, this also uses the new viewutils extension and uses `textview.visibility = View.GONE` instead of `textview.setVisibility(View.GONE)`