### PR TITLE
fix: disable 'smooth keyboard' animation

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/PluginManager.kt
+++ b/Aliucord/src/main/java/com/aliucord/PluginManager.kt
@@ -272,8 +272,8 @@ object PluginManager {
     @JvmStatic
     fun loadCorePlugins(context: Context) {
         val corePlugins = arrayOf(
-            AppBarFix(),
             AlignThreads(),
+            AppBarFix(),
             ButtonsAPI(),
             CommandHandler(),
             CoreCommands(),

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/AppBarFix.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/AppBarFix.kt
@@ -6,10 +6,7 @@ import com.aliucord.entities.CorePlugin
 import com.aliucord.patcher.instead
 import com.discord.widgets.chat.input.SmoothKeyboardReactionHelper
 
-
 internal class AppBarFix : CorePlugin(Manifest("AppBarFix")) {
-    override val isHidden = true
-
     init {
         manifest.description = "Fixes erratic AppBarLayout behavior by disabling 'smooth keyboard' animation"
     }
@@ -18,7 +15,5 @@ internal class AppBarFix : CorePlugin(Manifest("AppBarFix")) {
         patcher.instead<SmoothKeyboardReactionHelper>("install", View::class.java) {}
     }
 
-    override fun stop(context: Context) {
-        patcher.unpatchAll()
-    }
+    override fun stop(context: Context) = patcher.unpatchAll()
 }


### PR DESCRIPTION
This coreplugin fixes weird toolbar animation issues by disabling Discord's sloppy "smooth keyboard" animation implementation.