### PR TITLE
feat: temporarily fix voice channels

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/PluginManager.kt
+++ b/Aliucord/src/main/java/com/aliucord/PluginManager.kt
@@ -326,7 +326,7 @@ object PluginManager {
             SupporterBadges(),
             TokenLogin(),
             UploadSize(),
-            VoiceFix()
+            VoiceFix(),
         )
 
         val safeMode = isSafeModeEnabled();

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/VoiceFix.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/VoiceFix.kt
@@ -3,14 +3,18 @@ package com.aliucord.coreplugins
 import android.content.Context
 import com.aliucord.entities.CorePlugin
 import com.aliucord.patcher.*
+import com.discord.rtcconnection.socket.io.Payloads.Protocol.ProtocolInfo
 
 internal class VoiceFix : CorePlugin(Manifest("VoiceFix"))  {
+    override val isHidden = true
+    override val isRequired = true
+
     init {
         manifest.description = "Fixes VC not working properly."
     }
 
     override fun start(context: Context) {
-        patcher.before<com.discord.rtcconnection.socket.io.Payloads.Protocol.ProtocolInfo>(
+        patcher.before<ProtocolInfo>(
             String::class.java,
             Int::class.javaPrimitiveType!!,
             String::class.java,


### PR DESCRIPTION
this adds a patch so instead of aliucord using the broken `"xsalsa20_poly1305"` mode, it uses the only really natively supported mode which is `"xsalsa20_poly1305_lite_rtpsize"`, this is only really temporary since discord is enforcing e2ee/libdave on 2026 and trying to use the aes-256 mode connects but sound doesn't work properly since well, it can't decrypt it...