### PR TITLE
feat: hide muted channels fix

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/PluginManager.kt
+++ b/Aliucord/src/main/java/com/aliucord/PluginManager.kt
@@ -308,6 +308,7 @@ object PluginManager {
             ExperimentDefaults(),
             ForwardedMessages(),
             GifPreviewFix(),
+            HideMutedChannelsFix(),
             MembersListFix(),
             NewPins(),
             NoTrack(),

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/HideMutedChannelsFix.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/HideMutedChannelsFix.kt
@@ -1,0 +1,26 @@
+package com.aliucord.coreplugins
+
+import android.content.Context
+import com.aliucord.entities.CorePlugin
+import com.aliucord.patcher.after
+import com.discord.widgets.channels.list.`WidgetChannelListModel$Companion$guildListBuilder$$inlined$forEach$lambda$1`
+import com.discord.widgets.channels.list.`WidgetChannelListModel$Companion$guildListBuilder$$inlined$forEach$lambda$1$2`
+
+@Suppress("MISSING_DEPENDENCY_CLASS")
+internal class HideMutedChannelsFix : CorePlugin(Manifest("HideMutedChannelsFix")) {
+    init {
+        manifest.description = "Fixes 'Hide Muted Channels' feature ignoring unread mentions"
+    }
+
+    override fun start(context: Context) {
+        patcher.after<`WidgetChannelListModel$Companion$guildListBuilder$$inlined$forEach$lambda$1$2`>("invoke") { param ->
+            if (this.`$mentionCount` > 0) {
+                val builder = this.`this$0` as `WidgetChannelListModel$Companion$guildListBuilder$$inlined$forEach$lambda$1`
+                builder.`$hiddenChannelsIds$inlined`.remove(this.`$textChannelId`)
+                param.result = false
+            }
+        }
+    }
+
+    override fun stop(context: Context) = patcher.unpatchAll()
+}


### PR DESCRIPTION
Fixes 'Hide Muted Channels' feature accidentally hiding channels that contain unread mentions.