### PR TITLE
fix: support autocomplete entries with the same name

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -22,6 +22,7 @@ import com.aliucord.utils.ReflectUtils
 import com.aliucord.utils.ViewUtils.findViewById
 import com.aliucord.utils.accessField
 import com.aliucord.wrappers.ChannelWrapper.Companion.id
+import com.aliucord.wrappers.GuildRoleWrapper.Companion.name
 import com.aliucord.wrappers.embeds.MessageEmbedWrapper
 import com.discord.api.channel.Channel
 import com.discord.api.message.embed.EmbedField
@@ -37,8 +38,10 @@ import com.discord.utilities.guildautomod.AutoModUtils
 import com.discord.utilities.lazy.memberlist.ChannelMemberList
 import com.discord.utilities.lazy.memberlist.MemberListRow
 import com.discord.utilities.permissions.PermissionUtils
+import com.discord.utilities.user.UserUtils
 import com.discord.widgets.channels.list.*
 import com.discord.widgets.chat.input.SmoothKeyboardReactionHelper
+import com.discord.widgets.chat.input.autocomplete.*
 import com.discord.widgets.chat.list.actions.`WidgetChatListActions$binding$2`
 import com.discord.widgets.chat.list.adapter.WidgetChatListAdapterItemAutoModSystemMessageEmbed
 import com.discord.widgets.chat.list.adapter.WidgetChatListAdapterItemThreadDraftForm
@@ -80,6 +83,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
         fixThreadsIcon()
         fixSlowmode()
         fixExternalLinks()
+        fixMissingAutocomplete()
     }
 
     private fun fixStockEmojis() = tryPatch("Fix built-in emojis") {
@@ -354,6 +358,32 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
             callback = Activity::handleIntent
         )
     }
+
+    private fun fixMissingAutocomplete() = tryPatch("Fixes missing autocomplete entries which have the same name") {
+        patcher.before<AutocompletableComparator>(
+            "compare",
+            Autocompletable::class.java,
+            Autocompletable::class.java,
+        ) { (param, p1: Autocompletable, p2: Autocompletable) ->
+            // For roles
+            if (p1 is RoleAutocompletable && p2 is RoleAutocompletable) {
+                param.result = compareValuesBy(
+                    p1, p2,
+                    { it.role.name }, // Compare by name first
+                    { it.role.id }, // Then compare by id
+                )
+            }
+            // For users
+            if (p1 is UserAutocompletable && p2 is UserAutocompletable) {
+                param.result = compareValuesBy(
+                    p1, p2,
+                    { it.nickname ?: it.user.username }, // Compare by nickname/display name first
+                    { it.user.username + UserUtils.INSTANCE.getDiscriminatorWithPadding(it.user) }, // Then compare by username[#discrim] (always unique)
+                )
+            }
+        }
+    }
+
 
     private fun tryPatch(label: String, block: () -> Unit) {
         try {

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -38,7 +38,6 @@ import com.discord.utilities.guildautomod.AutoModUtils
 import com.discord.utilities.lazy.memberlist.ChannelMemberList
 import com.discord.utilities.lazy.memberlist.MemberListRow
 import com.discord.utilities.permissions.PermissionUtils
-import com.discord.utilities.user.UserUtils
 import com.discord.widgets.channels.list.*
 import com.discord.widgets.chat.input.SmoothKeyboardReactionHelper
 import com.discord.widgets.chat.input.autocomplete.*
@@ -372,13 +371,13 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
                     { it.role.name }, // Compare by name first
                     { it.role.id }, // Then compare by id
                 )
-            }
             // For users
-            if (p1 is UserAutocompletable && p2 is UserAutocompletable) {
+            } else if (p1 is UserAutocompletable && p2 is UserAutocompletable) {
                 param.result = compareValuesBy(
                     p1, p2,
                     { it.nickname ?: it.user.username }, // Compare by nickname/display name first
-                    { it.user.username + UserUtils.INSTANCE.getDiscriminatorWithPadding(it.user) }, // Then compare by username[#discrim] (always unique)
+                    { it.user.username }, // Then compare by username
+                    { it.user.discriminator }, // Then compare by discrim
                 )
             }
         }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -6,9 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
-import android.os.Build
-import android.os.Bundle
-import android.os.SystemClock
+import android.os.*
 import android.view.View
 import android.view.WindowInsetsAnimation
 import android.widget.TextView
@@ -346,7 +344,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
     }
 
     // Forces app links to always open in a separate window, except for custom tab. This addresses an issue where some links are opened internally on certain ROMs
-    private fun fixExternalLinks() = tryPatch("Fixes app links not being handled by their respective app") {
+    private fun fixExternalLinks() = tryPatch("Fix app links not being handled by their respective app") {
         @Suppress("UnusedReceiverParameter")
         fun Activity.handleIntent(param: MethodHookParam) {
             val intent = param.args[0] as? Intent ?: return
@@ -369,7 +367,10 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
         ReflectUtils.setField(ClockFactory.INSTANCE, "ntpClock", NtpClock(AndroidClock()))
     }
 
-    private fun fixMissingAutocomplete() = tryPatch("Fixes missing autocomplete entries which have the same name") {
+    private fun fixMissingAutocomplete() = tryPatch("Fix missing autocomplete entries which have the same name") {
+        // Replaces the comparator used to add entries to the autocomplete set.
+        // Fixes an issue where entries with the same name won't show up apart from the first one
+        // e.g. setting your nickname the same as someone else
         patcher.before<AutocompletableComparator>(
             "compare",
             Autocompletable::class.java,


### PR DESCRIPTION
Most notable when two people have the same nickname/display name — only one would show up as the autocompletes are backed by a treeset and the comparator only compares the names. This PR makes the comparator also check for username[#discrim] to ensure all entries are shown