### PR TITLE
fix: disable NTP clock

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -363,8 +363,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
     private fun fixClock() = tryPatch("Fix Clock provider") {
         // Replace NTP clock with local system clock
         // SAFETY: This is safe to run directly since ClockFactory initializes before Aliucord core initializes.
-        val ntpClock = NtpClock(AndroidClock())
-        ReflectUtils.setField(ClockFactory.INSTANCE, "ntpClock", ntpClock)
+        ReflectUtils.setField(ClockFactory.INSTANCE, "ntpClock", NtpClock(AndroidClock()))
     }
 
     private fun tryPatch(label: String, block: () -> Unit) {

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -87,12 +87,6 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
         fixClock()
     }
 
-    private fun fixClock() = tryPatch("Fix Clock provider") {
-        // Replace NTP clock with local system clock
-        // SAFETY: This is safe to run directly since ClockFactory initializes before Aliucord core initializes.
-        val ntpClock = NtpClock(AndroidClock())
-        ReflectUtils.setField(ClockFactory.INSTANCE, "ntpClock", ntpClock)
-    }
     private fun fixStockEmojis() = tryPatch("Fix built-in emojis") {
         // Patch to repair built-in emotes is needed because installer doesn't recompile resources,
         // so they stay in package com.discord instead of apk package name
@@ -366,6 +360,13 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
         )
     }
 
+    private fun fixClock() = tryPatch("Fix Clock provider") {
+        // Replace NTP clock with local system clock
+        // SAFETY: This is safe to run directly since ClockFactory initializes before Aliucord core initializes.
+        val ntpClock = NtpClock(AndroidClock())
+        ReflectUtils.setField(ClockFactory.INSTANCE, "ntpClock", ntpClock)
+    }
+
     private fun tryPatch(label: String, block: () -> Unit) {
         try {
             block()
@@ -375,9 +376,8 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
     }
 }
 
-class AndroidClock: KronosClock {
+private class AndroidClock: KronosClock {
     override fun a(): Long = System.currentTimeMillis()
-
 
     override fun b(): Long = SystemClock.elapsedRealtime()
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -8,6 +8,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.SystemClock
 import android.view.View
 import android.view.WindowInsetsAnimation
 import android.widget.TextView
@@ -37,6 +38,8 @@ import com.discord.utilities.guildautomod.AutoModUtils
 import com.discord.utilities.lazy.memberlist.ChannelMemberList
 import com.discord.utilities.lazy.memberlist.MemberListRow
 import com.discord.utilities.permissions.PermissionUtils
+import com.discord.utilities.time.ClockFactory
+import com.discord.utilities.time.NtpClock
 import com.discord.widgets.channels.list.*
 import com.discord.widgets.chat.input.SmoothKeyboardReactionHelper
 import com.discord.widgets.chat.list.actions.`WidgetChatListActions$binding$2`
@@ -46,6 +49,7 @@ import com.discord.widgets.chat.list.entries.*
 import com.discord.widgets.chat.overlay.WidgetChatOverlay
 import com.discord.widgets.guilds.list.`WidgetGuildsListViewModel$createDirectMessageItems$1`
 import com.linecorp.apng.decoder.Apng
+import com.lyft.kronos.KronosClock
 import com.lytefast.flexinput.R
 import de.robv.android.xposed.XC_MethodHook.MethodHookParam
 
@@ -80,8 +84,15 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
         fixThreadsIcon()
         fixSlowmode()
         fixExternalLinks()
+        fixClock()
     }
 
+    private fun fixClock() = tryPatch("Fix Clock provider") {
+        // Replace NTP clock with local system clock
+        // SAFETY: This is safe to run directly since ClockFactory initializes before Aliucord core.
+        val ntpClock = NtpClock(AndroidClock())
+        ReflectUtils.setField(ClockFactory.INSTANCE, "ntpClock", ntpClock)
+    }
     private fun fixStockEmojis() = tryPatch("Fix built-in emojis") {
         // Patch to repair built-in emotes is needed because installer doesn't recompile resources,
         // so they stay in package com.discord instead of apk package name
@@ -362,4 +373,11 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
             Main.logger.error("Failed to apply patch: \"$label\"", e)
         }
     }
+}
+
+class AndroidClock: KronosClock {
+    override fun a(): Long = System.currentTimeMillis()
+
+
+    override fun b(): Long = SystemClock.elapsedRealtime()
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -89,7 +89,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
 
     private fun fixClock() = tryPatch("Fix Clock provider") {
         // Replace NTP clock with local system clock
-        // SAFETY: This is safe to run directly since ClockFactory initializes before Aliucord core.
+        // SAFETY: This is safe to run directly since ClockFactory initializes before Aliucord core initializes.
         val ntpClock = NtpClock(AndroidClock())
         ReflectUtils.setField(ClockFactory.INSTANCE, "ntpClock", ntpClock)
     }


### PR DESCRIPTION
Disables the overly engineered horrible NTP clock library in app and replaces it with local system clock.
Prevents weird behavior caused by mismatching clock data (e.g date formatters breaking, old timeouts suddenly being reapplied)

This code should switch to hooking ClockFactory::init after early-init is implemented.