### PR TITLE
fix(PluginUpdater): treat invalid local plugin versions as outdated

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/updater/PluginUpdater.kt
+++ b/Aliucord/src/main/java/com/aliucord/updater/PluginUpdater.kt
@@ -82,13 +82,17 @@ internal object PluginUpdater {
                         ?.takeIf { it.isNotEmpty() }
                         ?: continue,
                 )
+                // Previous attempt at retrieving updater data failed
                 if (info == null) {
                     logger.warn("Failed to check updates for plugin ${plugin.name} (${plugin.__filename}.zip)")
                     continue
                 }
 
+                // Assume invalid local versions are always out of date
+                val localVersion = SemVer.parseOrNull(plugin.manifest.version) ?: SemVer.Zero
+
                 // Plugin is already up-to-date
-                if (SemVer.parse(plugin.manifest.version) >= info.version)
+                if (localVersion >= info.version)
                     continue
 
                 updates += PluginUpdate(


### PR DESCRIPTION
This fixes updater issue on 6 obscure plugins that have had non-semver version strings.
All currently published plugins now follow semver version format