### PR TITLE
feat: Improve PluginUpdater

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/screens/UpdaterScreen.kt
+++ b/Aliucord/src/main/java/com/aliucord/screens/UpdaterScreen.kt
@@ -2,9 +2,9 @@ package com.aliucord.screens
 
 import android.graphics.Color
 import android.os.Bundle
-import android.view.*
-import android.widget.TextView
-import android.widget.Toast
+import android.view.Gravity
+import android.view.View
+import android.widget.*
 import com.aliucord.Utils
 import com.aliucord.fragments.SettingsPage
 import com.aliucord.settings.AliucordPage
@@ -18,6 +18,7 @@ import com.lytefast.flexinput.R
 internal class UpdaterScreen : SettingsPage() {
     private val updateSource = PluginUpdaterSource()
     private val updates = mutableListOf<PluginUpdater.PluginUpdate>()
+    private var isRefreshing = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,6 +40,7 @@ internal class UpdaterScreen : SettingsPage() {
 
         super.onViewBound(view)
         setActionBarTitle("Updater")
+        linearLayout.removeAllViews()
 
         addHeaderButton("Refresh", R.e.ic_refresh_white_a60_24dp) { item ->
             item.isEnabled = false
@@ -68,6 +70,11 @@ internal class UpdaterScreen : SettingsPage() {
                 .show()
         }
 
+        if (isRefreshing) {
+            ProgressBar(context).addTo(linearLayout)
+            return
+        }
+
         if (updates.isEmpty()) {
             TextView(context, null, 0, R.i.UiKit_Settings_Item_SubText).addTo(linearLayout) {
                 text = "No updates found!"
@@ -82,20 +89,27 @@ internal class UpdaterScreen : SettingsPage() {
     }
 
     private fun refreshUpdates() {
+        if (isRefreshing) return
+        isRefreshing = true
+
         Utils.threadPool.execute {
-            updates.clear()
-            updates.addAll(PluginUpdater.fetchUpdates(updateSource))
+            try {
+                updates.clear()
+                updates.addAll(PluginUpdater.fetchUpdates(updateSource))
 
-            val noticeText = if (updates.isNotEmpty()) {
-                "Found ${Utils.pluralise(updates.size, "plugin update")}!"
-            } else {
-                "No plugin updates found!"
-            }
+                val noticeText = if (updates.isNotEmpty()) {
+                    "Found ${Utils.pluralise(updates.size, "plugin update")}!"
+                } else {
+                    "No plugin updates found!"
+                }
 
-            Utils.mainThread.post {
-                setActionBarSubtitle(null)
-                Toast.makeText(context, noticeText, Toast.LENGTH_SHORT).show()
-                reRender()
+                Utils.mainThread.post {
+                    setActionBarSubtitle(null)
+                    Toast.makeText(context, noticeText, Toast.LENGTH_SHORT).show()
+                    reRender()
+                }
+            } finally {
+                isRefreshing = false
             }
         }
     }
@@ -112,6 +126,8 @@ internal class UpdaterScreen : SettingsPage() {
             val (succeeded, failed) = updates
                 .filter { it.isUpdatePossible() }
                 .partition(PluginUpdater::updatePlugin)
+
+            if (succeeded.any { it.plugin.requiresRestart() }) Utils.promptRestart("Plugin update requires a restart. Restart now?")
 
             Utils.mainThread.post {
                 setActionBarSubtitle(null)

--- a/Aliucord/src/main/java/com/aliucord/updater/CoreUpdater.kt
+++ b/Aliucord/src/main/java/com/aliucord/updater/CoreUpdater.kt
@@ -23,7 +23,7 @@ internal object CoreUpdater {
     /**
      * Fetches the remote build info.
      */
-    private fun fetchAliucordData(): BuildData {
+    fun fetchAliucordData(): BuildData {
         return Http.simpleJsonGet(UPDATER_DATA_URL, BuildData::class.java)
     }
 
@@ -38,36 +38,35 @@ internal object CoreUpdater {
             logger.debug("Checking for Aliucord updates...")
             val data = fetchAliucordData()
 
-            if (data.coreVersion > SemVer.parse(BuildConfig.VERSION)) {
-                if (Constants.DISCORD_VERSION < data.discordVersion
-                    || !ManagerBuild.hasKotlin(data.kotlinVersion.toString())
-                    || !ManagerBuild.hasInjector(data.kotlinVersion.toString())
-                    || !ManagerBuild.hasPatches(data.patchesVersion.toString())
-                ) {
-                    val notificationData = NotificationData()
-                        .setTitle("Updater")
-                        .setBody("This installation is outdated!\n" +
-                            "Click to reinstall Aliucord using Aliucord Manager...")
-                        .setAutoDismissPeriodSecs(10)
-                        .setOnClick { reinstallAliucord() }
-
-                    NotificationsAPI.display(notificationData)
-                } else if (!isAutoUpdateEnabled()) {
-                    val notificationData = NotificationData()
-                        .setTitle("Updater")
-                        .setBody("Aliucord has an update available!\n" +
-                            "Click to automatically update...")
-                        .setAutoDismissPeriodSecs(10)
-                        // TODO: open Updater screen instead once it support showing core updates
-                        .setOnClick { updateAliucord() }
-
-                    NotificationsAPI.display(notificationData)
-                } else {
-                    updateAliucord()
-                }
-            } else {
+            if (data.coreVersion <= SemVer.parse(BuildConfig.VERSION)) {
                 logger.debug("No updates found!")
+                return
             }
+
+            if (Constants.DISCORD_VERSION < data.discordVersion
+                || !ManagerBuild.hasKotlin(data.kotlinVersion.toString())
+                || !ManagerBuild.hasInjector(data.kotlinVersion.toString())
+                || !ManagerBuild.hasPatches(data.patchesVersion.toString())
+            ) {
+                NotificationsAPI.display(NotificationData()
+                    .setTitle("Updater")
+                    .setBody("This installation is outdated!\nClick to reinstall Aliucord using Aliucord Manager...")
+                    .setAutoDismissPeriodSecs(10)
+                    .setOnClick { reinstallAliucord() })
+                return
+            }
+
+            if (!isAutoUpdateEnabled()) {
+                NotificationsAPI.display(NotificationData()
+                    .setTitle("Updater")
+                    .setBody("Aliucord has an update available!\nClick to automatically update...")
+                    .setAutoDismissPeriodSecs(10)
+                    // TODO: open Updater screen instead once it support showing core updates
+                    .setOnClick { updateAliucord() })
+                return
+            }
+
+            updateAliucord()
         } catch (e: Exception) {
             logger.errorToast("Failed to check updates for Aliucord", e)
         }
@@ -169,7 +168,7 @@ internal object CoreUpdater {
     /**
      * The model of the data available at [UPDATER_DATA_URL].
      */
-    private data class BuildData(
+    internal data class BuildData(
         @SerializedName("versionCode")
         var discordVersion: Int,
         var coreVersion: SemVer,

--- a/Aliucord/src/main/java/com/aliucord/updater/PluginUpdater.kt
+++ b/Aliucord/src/main/java/com/aliucord/updater/PluginUpdater.kt
@@ -7,6 +7,7 @@ import com.aliucord.entities.Plugin
 import com.aliucord.settings.AUTO_UPDATE_PLUGINS_KEY
 import com.aliucord.utils.SemVer
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
 
 /**
@@ -74,12 +75,38 @@ internal object PluginUpdater {
 
         val updates = mutableListOf<PluginUpdate>()
         val mainInfo = source.getMainManifestBuildInfo()
+        val regex = Regex(
+            """(?:cdn\.jsdelivr\.net/gh/|raw\.githubusercontent\.com/|github\.com/)([^/]+)/([^/@]+)"""
+        )
+
+        val urlsCache = ConcurrentHashMap<String, Pair<String, String>>()
+        val comparisonCache = ConcurrentHashMap<Pair<String, String>, Boolean>()
+
+        fun compareUrls(a: String?, b: String?): Boolean {
+            if (a == null || b == null) return false
+
+            val key = if (a <= b) a to b else b to a
+
+            return comparisonCache.getOrPut(key) {
+                fun parse(url: String): Pair<String, String>? {
+                    return urlsCache.getOrPut(url) {
+                        val m = regex.find(url, 0) ?: return@getOrPut null
+                        m.groupValues[1] to m.groupValues[2]
+                    }
+                }
+
+                val p1 = parse(a) ?: return@getOrPut false
+                val p2 = parse(b) ?: return@getOrPut false
+                p1 == p2
+            }
+        }
 
         // Check if a plugin has an update available and add it to the list
         fun checkAndAdd(plugin: Plugin, name: String, repo: Map<String, PluginUpdaterSource.PluginBuildInfo>?): Boolean {
             try {
                 // Plugin not found in repo
                 val info = repo?.get(name) ?: return false
+                if (!compareUrls(info.repoUrl, plugin.manifest.updateUrl)) return false
 
                 // Assume invalid local versions are always out of date
                 val local = SemVer.parseOrNull(plugin.manifest.version) ?: SemVer.Zero
@@ -107,12 +134,11 @@ internal object PluginUpdater {
         // Fetch all remaining repos in parallel
         val executor = Executors.newFixedThreadPool(4)
         try {
-            fallback.mapValues { (url, plugins) ->
+            fallback.map { (url, plugins) ->
                 plugins to executor.submit<Map<String, PluginUpdaterSource.PluginBuildInfo>?> {
                     source.getRepoBuildInfo(url)
                 }
-            }.forEach { (_, value) ->
-                val (plugins, future) = value
+            }.forEach { (plugins, future) ->
                 val repo = future.get() ?: return@forEach
                 plugins.forEach { (plugin, name) -> checkAndAdd(plugin, name, repo) }
             }

--- a/Aliucord/src/main/java/com/aliucord/updater/PluginUpdater.kt
+++ b/Aliucord/src/main/java/com/aliucord/updater/PluginUpdater.kt
@@ -7,6 +7,7 @@ import com.aliucord.entities.Plugin
 import com.aliucord.settings.AUTO_UPDATE_PLUGINS_KEY
 import com.aliucord.utils.SemVer
 import java.io.File
+import java.util.concurrent.Executors
 
 /**
  * Manages fetching and installing plugin updates.
@@ -72,39 +73,53 @@ internal object PluginUpdater {
         logger.info("Checking for plugin updates...")
 
         val updates = mutableListOf<PluginUpdate>()
-        for (plugin in PluginManager.plugins.values) {
-            try {
-                if (plugin is CorePlugin) continue
+        val mainInfo = source.getMainManifestBuildInfo()
 
-                val info = source.getPluginBuildInfo(
-                    pluginName = plugin.manifest.name ?: continue,
-                    updateInfoUrl = plugin.manifest.updateUrl
-                        ?.takeIf { it.isNotEmpty() }
-                        ?: continue,
-                )
-                // Previous attempt at retrieving updater data failed
-                if (info == null) {
-                    logger.warn("Failed to check updates for plugin ${plugin.name} (${plugin.__filename}.zip)")
-                    continue
-                }
+        // Check if a plugin has an update available and add it to the list
+        fun checkAndAdd(plugin: Plugin, name: String, repo: Map<String, PluginUpdaterSource.PluginBuildInfo>?): Boolean {
+            try {
+                // Plugin not found in repo
+                val info = repo?.get(name) ?: return false
 
                 // Assume invalid local versions are always out of date
-                val localVersion = SemVer.parseOrNull(plugin.manifest.version) ?: SemVer.Zero
+                val local = SemVer.parseOrNull(plugin.manifest.version) ?: SemVer.Zero
 
                 // Plugin is already up-to-date
-                if (localVersion >= info.version)
-                    continue
+                if (local >= info.version) return true
 
-                updates += PluginUpdate(
-                    plugin = plugin,
-                    pluginName = plugin.name,
-                    info = info,
-                )
+                updates += PluginUpdate(plugin, name, info)
+                return true
             } catch (e: Exception) {
-                logger.error("Failed checking updates for plugin ${plugin.name} (${plugin.__filename}.zip)", e)
-                continue
+                logger.error("Failed checking updates for ${plugin.name} (${plugin.__filename}.zip)", e)
+                return false
             }
         }
+
+        // Check main manifest first, group remaining plugins by their update URL for parallel fetching
+        val fallback = mutableMapOf<String, MutableList<Pair<Plugin, String>>>()
+        for (plugin in PluginManager.plugins.values) {
+            if (plugin is CorePlugin) continue
+            val name = plugin.manifest.name ?: continue
+            val url = plugin.manifest.updateUrl?.takeIf(String::isNotEmpty) ?: continue
+            if (!checkAndAdd(plugin, name, mainInfo)) fallback.getOrPut(url) { mutableListOf() }.add(plugin to name)
+        }
+
+        // Fetch all remaining repos in parallel
+        val executor = Executors.newFixedThreadPool(4)
+        try {
+            fallback.mapValues { (url, plugins) ->
+                plugins to executor.submit<Map<String, PluginUpdaterSource.PluginBuildInfo>?> {
+                    source.getRepoBuildInfo(url)
+                }
+            }.forEach { (_, value) ->
+                val (plugins, future) = value
+                val repo = future.get() ?: return@forEach
+                plugins.forEach { (plugin, name) -> checkAndAdd(plugin, name, repo) }
+            }
+        } finally {
+            executor.shutdown()
+        }
+
         return updates
     }
 
@@ -122,26 +137,13 @@ internal object PluginUpdater {
                 resp.saveToFile(File(Constants.PLUGINS_PATH, "${update.plugin.__filename}.zip"))
             }
 
-            reloadPlugin(update.plugin)
+            Utils.mainThread.post {
+                PluginManager.remountPlugin(update.plugin.name)
+            }
             true
         } catch (e: Exception) {
             logger.error("Failed to update plugin ${update.plugin} (${update.plugin.__filename}.zip)", e)
             false
-        }
-    }
-
-    private fun reloadPlugin(plugin: Plugin) {
-        // FIXME: plugin not reloaded when disabled
-        if (!PluginManager.isPluginEnabled(plugin.name)) return
-
-        Utils.mainThread.post {
-            PluginManager.remountPlugin(plugin.name)
-            val newPlugin = PluginManager.plugins[plugin.name] ?: return@post
-
-            // FIXME: only prompt once when updating all plugins at once
-            if (plugin.requiresRestart() || newPlugin.requiresRestart()) {
-                Utils.promptRestart("Plugin update requires a restart. Restart now?")
-            }
         }
     }
 }

--- a/Aliucord/src/main/java/com/aliucord/updater/PluginUpdaterSource.kt
+++ b/Aliucord/src/main/java/com/aliucord/updater/PluginUpdaterSource.kt
@@ -2,10 +2,10 @@ package com.aliucord.updater
 
 import com.aliucord.Http
 import com.aliucord.Logger
-import com.aliucord.entities.Plugin
 import com.aliucord.utils.*
 import com.aliucord.utils.GsonUtils.fromJson
 import com.google.gson.reflect.TypeToken
+import java.lang.reflect.Type
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
@@ -14,6 +14,8 @@ import java.util.concurrent.TimeUnit
  */
 internal class PluginUpdaterSource {
     private val logger = Logger("Updater/Plugins/Source")
+    private val rawGithubRegex =
+        "https://raw\\.githubusercontent\\.com/(.+?)/(.+?)/(.+)".toRegex()
 
     /**
      * A TTL cache of updater data from plugin repositories.
@@ -22,56 +24,37 @@ internal class PluginUpdaterSource {
     private val cachedRepoInfo = ConcurrentHashMap<String, RepoBuildInfo>()
 
     /**
-     * Retrieves the update info for a specific plugin.
-     * @param pluginName The plugin's manifest name.
-     * @param updateInfoUrl The plugin's repository's update info url. [Plugin.Manifest.updateUrl]
-     */
-    fun getPluginBuildInfo(pluginName: String, updateInfoUrl: String): PluginBuildInfo? {
-        return getRepoBuildInfo(updateInfoUrl)?.get(pluginName)
-    }
-
-    /**
      * Retrieves the update info for a plugin repository.
      * @return Record of plugin name -> plugin updater info, or `null` if data failed to fetch.
      */
     fun getRepoBuildInfo(updateInfoUrl: String): Map<String, PluginBuildInfo>? {
-        // Replace raw.githubusercontent.com urls with jsdelivr to avoid rate limiting
-        val realUpdateInfoUrl = updateInfoUrl.replace(
-            "https://raw\\.githubusercontent\\.com/(.+?)/(.+?)/(.+)".toRegex(),
-            "https://cdn.jsdelivr.net/gh/$1/$2@$3"
-        )
+        val url = updateInfoUrl.replace(rawGithubRegex, "https://cdn.jsdelivr.net/gh/$1/$2@$3")
 
-        cachedRepoInfo[realUpdateInfoUrl]?.let {
-            if (System.currentTimeMillis() < it.expiration) {
-                return it.plugins
-            } else {
-                cachedRepoInfo.remove(realUpdateInfoUrl)
-            }
+        cachedRepoInfo[url]?.let {
+            if (System.currentTimeMillis() < it.expiration) return it.plugins
+            cachedRepoInfo.remove(url)
         }
 
+        val json = fetchJson<Map<String, PluginBuildInfo>>(url)
+        cachedRepoInfo[url] = RepoBuildInfo(plugins = json)
+        return json
+    }
+
+    fun getMainManifestBuildInfo(): Map<String, PluginBuildInfo>? {
+        return fetchJson<List<PluginBuildInfo>>("https://plugins.aliucord.com/manifest.json")
+            ?.associateBy { it.name!! }
+    }
+
+    private inline fun <reified T> fetchJson(url: String, type: Type = object : TypeToken<T>() {}.type): T? {
         try {
-            val resp = Http.Request(realUpdateInfoUrl).execute()
-
-            // If update url doesn't exist, don't retry
-            if (resp.statusCode == 404) {
-                cachedRepoInfo[realUpdateInfoUrl] = RepoBuildInfo(plugins = null)
-            }
-
+            val resp = Http.Request(url).execute()
             if (!resp.ok()) {
-                logger.warn("Failed to fetch plugin update info from $realUpdateInfoUrl, " +
-                    "Status ${resp.statusCode}, " +
-                    "Response: ${resp.text()}")
+                logger.warn("Failed to fetch $url, Status ${resp.statusCode}, Response: ${resp.text()}")
                 return null
             }
-
-            val jsonType = TypeToken.getParameterized(Map::class.java, String::class.java, PluginBuildInfo::class.java).getType()
-            val json = GsonUtils.gson.fromJson<Map<String, PluginBuildInfo>>(resp.text(), jsonType)
-
-            cachedRepoInfo[realUpdateInfoUrl] = RepoBuildInfo(plugins = json)
-            return json
+            return GsonUtils.gson.fromJson(resp.text(), type)
         } catch (e: Exception) {
-            cachedRepoInfo[realUpdateInfoUrl] = RepoBuildInfo(plugins = null)
-            logger.warn("Failed to fetch plugin update info from $realUpdateInfoUrl", e)
+            logger.warn("Failed to fetch plugin update info from $url", e)
             return null
         }
     }
@@ -80,8 +63,9 @@ internal class PluginUpdaterSource {
      * Latest build info for a specific plugin.
      */
     data class PluginBuildInfo(
+        var name: String? = null,
         var version: SemVer,
-        @SerializedName("build")
+        @SerializedName("build", alternate = ["url"])
         var buildUrl: String,
         var buildCrc32: String? = null,
         var changelog: String? = null,

--- a/Aliucord/src/main/java/com/aliucord/updater/PluginUpdaterSource.kt
+++ b/Aliucord/src/main/java/com/aliucord/updater/PluginUpdaterSource.kt
@@ -65,6 +65,7 @@ internal class PluginUpdaterSource {
     data class PluginBuildInfo(
         var name: String? = null,
         var version: SemVer,
+        var repoUrl: String? = null,
         @SerializedName("build", alternate = ["url"])
         var buildUrl: String,
         var buildCrc32: String? = null,


### PR DESCRIPTION
- [x] Use Aliucord/plugins-repo when possible
- [x]  Parallelize fallback update fetches
- [x]  Show single prompt to restart instead of one for each plugin that requires it
- [x]  Fix duplicate update cards issues
- [x]  Add loading indicator when fetching in update screen
- [ ] Show update card for core when auto-core updates are disabled
- [ ] Improve notifications
- [ ] Share state between notification and screen