### PR TITLE
fix(NewPins): Handle empty pins exception

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/NewPins.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/NewPins.kt
@@ -121,7 +121,7 @@ internal class NewPins : CorePlugin(Manifest("NewPins")) {
                     val data = res.json(GsonUtils.gsonRestApi, GetChannelPinsResponse::class.java)
                     val state = PinStateExtra.of(channelId)
                     state.hasMore = data.hasMore
-                    state.oldestPinTimestamp = data.items.last().pinnedAt
+                    state.oldestPinTimestamp = data.items.lastOrNull()?.pinnedAt
                     subscriber.onNext(data.items.map { it.message })
                 }
                 subscriber.onCompleted()


### PR DESCRIPTION
NewPins plugin does not account for empty fetch responses, causing code to throw an exception upon trying to retrieve oldest pin timestamp.