### PR TITLE
feat(TokenLogin): UI feedback

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/TokenLogin.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/TokenLogin.java
@@ -11,6 +11,7 @@ import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 
+import com.aliucord.Http;
 import com.aliucord.Utils;
 import com.aliucord.entities.CorePlugin;
 import com.aliucord.patcher.Patcher;
@@ -23,11 +24,13 @@ import com.discord.models.domain.auth.ModelLoginResult;
 import com.discord.stores.StoreAuthentication;
 import com.discord.stores.StoreStream;
 import com.discord.utilities.view.extensions.ViewExtensions;
+import com.discord.views.LoadingButton;
 import com.discord.widgets.auth.WidgetAuthLanding;
 import com.google.android.material.button.MaterialButton;
 import com.google.android.material.textfield.TextInputLayout;
 import com.lytefast.flexinput.R;
 
+import java.io.IOException;
 import java.util.*;
 
 import kotlin.Unit;
@@ -39,6 +42,8 @@ public final class TokenLogin extends CorePlugin {
     }
 
     public static class Page extends AppFragment {
+        private LoadingButton loginButton;
+
         public Page() {
             super(Utils.getResId("widget_auth_login", "layout"));
         }
@@ -48,6 +53,8 @@ public final class TokenLogin extends CorePlugin {
             super.onViewBound(view);
 
             LinearLayout v = view.findViewById(Utils.getResId("auth_login_container", "id"));
+            if (v == null) return; // prevent crash if layout change
+
             v.removeViewAt(1); // remove email input
             v.removeViewAt(2); // remove forgot password
             v.removeViewAt(2); // remove use a password manager
@@ -56,23 +63,60 @@ public final class TokenLogin extends CorePlugin {
             if (input != null) {
                 input.setHint("Token");
                 ViewExtensions.setOnImeActionDone(input, false, e -> {
-                    if (!e.getText().equals("")) login(e.getText());
+                    login(e.getText());
                     return Unit.a;
                 });
             }
 
             MaterialButton button = (MaterialButton) v.getChildAt(2);
             if (button != null) {
-                button.setOnClickListener(e -> {
-                    if (input == null || input.getEditText() == null) return;
-                    CharSequence token = input.getEditText().getText();
-                    if (!token.equals("")) login(token);
+                loginButton = new LoadingButton(view.getContext(), null);
+                loginButton.setIsLoading(false);
+                loginButton.setText(button.getText());
+                int i = v.indexOfChild(button);
+                v.removeViewAt(i);
+                v.addView(loginButton, i, button.getLayoutParams());
+                loginButton.setOnClickListener(e -> {
+                    if (input != null && input.getEditText() != null) login(input.getEditText().getText());
                 });
             }
         }
 
         public void login(CharSequence token) {
-            StoreAuthentication.access$dispatchLogin(StoreStream.getAuthentication(), new ModelLoginResult(token.toString().startsWith("mfa."), null, token.toString().trim(), null, new ArrayList<>()));
+            String trimmedToken = token.toString().trim();
+            if (trimmedToken.isEmpty()) {
+                Utils.showToast("Token cannot be empty");
+                return;
+            }
+            setLoading(true);
+            Utils.threadPool.execute(() -> {
+                try (Http.Request req = Http.Request.newDiscordRNRequest("/users/@me")
+                        .setHeader("Authorization", trimmedToken)
+                        .setRequestTimeout(10000)) {
+                    req.execute().assertOk();
+                    StoreAuthentication.access$dispatchLogin(
+                        StoreStream.getAuthentication(),
+                        new ModelLoginResult(trimmedToken.startsWith("mfa."), null, trimmedToken, null, new ArrayList<>())
+                    );
+                } catch (Http.HttpException e) {
+                    setLoading(false);
+                    Utils.showToast("Invalid token: " + e.statusCode + ": " + e.statusMessage);
+                } catch (IOException e) {
+                    setLoading(false);
+                    Utils.showToast("Failed to verify token: " + e.getMessage());
+                }
+            });
+        }
+
+        private void setLoading(boolean state) {
+            if (loginButton == null) return;
+            if (state) {
+                loginButton.setIsLoading(true);
+                loginButton.setEnabled(false);
+            } else Utils.mainThread.post(() -> {
+                loginButton.setIsLoading(false);
+                loginButton.setEnabled(true);
+            });
         }
     }
 

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/TokenLogin.java
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/TokenLogin.java
@@ -99,24 +99,27 @@ public final class TokenLogin extends CorePlugin {
                         new ModelLoginResult(trimmedToken.startsWith("mfa."), null, trimmedToken, null, new ArrayList<>())
                     );
                 } catch (Http.HttpException e) {
-                    setLoading(false);
                     Utils.showToast("Invalid token: " + e.statusCode + ": " + e.statusMessage);
                 } catch (IOException e) {
-                    setLoading(false);
                     Utils.showToast("Failed to verify token: " + e.getMessage());
+                } finally {
+                    setLoading(false);
                 }
             });
         }
 
         private void setLoading(boolean state) {
             if (loginButton == null) return;
+
             if (state) {
                 loginButton.setIsLoading(true);
                 loginButton.setEnabled(false);
-            } else Utils.mainThread.post(() -> {
-                loginButton.setIsLoading(false);
-                loginButton.setEnabled(true);
-            });
+            } else {
+                Utils.mainThread.post(() -> {
+                    loginButton.setIsLoading(false);
+                    loginButton.setEnabled(true);
+                });
+            }
         }
     }
 


### PR DESCRIPTION
## Whats this

Logging in with a token previously gave absolutely 0 user feedback, so when trying to login with an invalid/expired token, it just silently fails with no visible change, leaving you clueless

Now:
- The token is validated by making a request to `/users/@me` before running the login dispatch
- Results surface via toasts: empty input, invalid token (status code and response included), and other errors
- While the token is being validated, the login button turns into a loading spinner and its state becomes disabled (before you could spam click while the validation was running)

## Preview

https://github.com/user-attachments/assets/5b951871-54a2-440b-a834-87beda83efb4

