### PR TITLE
perf: Core fixes

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/Utils.kt
+++ b/Aliucord/src/main/java/com/aliucord/Utils.kt
@@ -186,23 +186,18 @@ Consider installing the MiXplorer file manager, or navigate to $path manually us
 """
 
             val ssb = SpannableStringBuilder(text).apply {
-                val mixText = "the MiXplorer file manager"
-                var start = text.indexOf(mixText)
-                var end = start + mixText.length
-                setSpan(object : ClickableSpan() {
+                fun mark(substring: String, span: Any) {
+                    val start = text.indexOf(substring)
+                    if (start != -1) setSpan(span, start, start + substring.length, SPAN_EXCLUSIVE_EXCLUSIVE)
+                }
+
+                mark("the MiXplorer file manager", object : ClickableSpan() {
                     override fun onClick(widget: View) {
                         launchUrl("https://forum.xda-developers.com/t/app-2-2-mixplorer-v6-x-released-fully-featured-file-manager.1523691/")
                     }
-                }, start, end, SPAN_EXCLUSIVE_EXCLUSIVE)
-
-                start = text.indexOf(path)
-                end = start + path.length
-                setSpan(StyleSpan(Typeface.BOLD_ITALIC), start, end, SPAN_EXCLUSIVE_EXCLUSIVE)
-
-                val explorerText = "your file explorer"
-                start = text.indexOf(explorerText)
-                end = start + explorerText.length
-                setSpan(object : ClickableSpan() {
+                })
+                mark(path, StyleSpan(Typeface.BOLD_ITALIC))
+                mark("your file explorer", object : ClickableSpan() {
                     override fun onClick(widget: View) {
                         Intent(Intent.ACTION_VIEW)
                             .setDataAndType(uri, DocumentsContract.Document.MIME_TYPE_DIR)
@@ -210,7 +205,7 @@ Consider installing the MiXplorer file manager, or navigate to $path manually us
                                 appActivity.startActivity(Intent.createChooser(it, "Open folder"))
                             }
                     }
-                }, start, end, SPAN_EXCLUSIVE_EXCLUSIVE)
+                })
             }
             ConfirmDialog()
                 .setTitle(":(")

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -197,6 +197,8 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
     private val GuildListViewHolder.GuildViewHolder.bindingGuild
         by accessField<WidgetGuildsListItemGuildBinding>()
 
+    private val guildIconUrls = WeakHashMap<View, String>()
+
     private fun patchIconU(name: String, vararg paramTypes: Class<*>) {
         patcher.patch(IconUtils::class.java.getDeclaredMethod(name, *paramTypes)) {
             it.result = (it.result as? String)
@@ -232,11 +234,22 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
             "configureGuildIconImage",
             Guild::class.java, Boolean::class.javaPrimitiveType!!,
         ) { (_, guild: Guild, animated: Boolean) ->
-            if (!guild.hasIcon()) return@after
+            val icon = bindingGuild.d
 
-            val size = IconUtils.getMediaProxySize(bindingGuild.d.layoutParams.height)
+            if (!guild.hasIcon()) {
+                guildIconUrls -= icon
+                return@after
+            }
+
+            val size = icon.layoutParams.height.takeIf { it > 0 }
+                ?.let(IconUtils::getMediaProxySize)
+                ?: return@after
+
             val url = IconUtils.getForGuild(guild, null, animated) + "&size=${size}"
-            MGImages.`setImage$default`(bindingGuild.d, url, size, size, false, null, null, 112, null)
+
+            if (guildIconUrls.put(icon, url) == url) return@after
+
+            MGImages.`setImage$default`(icon, url, size, size, false, null, null, 112, null)
         }
 
         // Support webp emojis by forcing every emoji to be webp

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -71,6 +71,8 @@ import com.discord.widgets.settings.profile.SettingsUserProfileViewModel
 import com.discord.widgets.settings.profile.WidgetEditUserOrGuildMemberProfile
 import com.discord.widgets.status.WidgetForumPostStatus
 import com.discord.widgets.status.WidgetForumPostStatusViewModel
+import com.discord.widgets.user.profile.UserProfileHeaderView
+import com.discord.widgets.user.profile.UserProfileHeaderViewModel
 import com.discord.widgets.user.usersheet.WidgetUserSheet
 import com.discord.widgets.user.usersheet.WidgetUserSheetViewModel
 import com.linecorp.apng.decoder.Apng
@@ -115,6 +117,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
         fixExternalLinks()
         fixClock()
         fixBioHeightLimit()
+        fixProfileBannerColorCrash()
         fixUnreadForumChannels()
         fixMemoryLeak()
     }
@@ -511,6 +514,20 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
             val binding = WidgetEditUserOrGuildMemberProfile.`access$getBinding$p`(this)
             binding.c.maxLines = Int.MAX_VALUE // bio editor input
             binding.h.maxLines = Int.MAX_VALUE // bio preview
+        }
+    }
+
+    private fun fixProfileBannerColorCrash() = tryPatch("Fix profile banner color thread crash") {
+        patcher.before<UserProfileHeaderView>(
+            "updateBannerColor",
+            UserProfileHeaderViewModel.ViewState.Loaded::class.java,
+        ) { param ->
+            if (Looper.myLooper() == Looper.getMainLooper()) return@before
+
+            val view = param.thisObject as UserProfileHeaderView
+            val state = param.args[0] as UserProfileHeaderViewModel.ViewState.Loaded
+            Utils.mainThread.post { view.updateBannerColor(state) }
+            param.result = null
         }
     }
 

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.*
+import android.text.InputFilter
 import android.view.View
 import android.view.WindowInsetsAnimation
 import android.widget.TextView
@@ -79,6 +80,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.linecorp.apng.decoder.Apng
 import com.lyft.kronos.KronosClock
 import com.lytefast.flexinput.R
+import com.lytefast.flexinput.widget.FlexEditText
 import de.robv.android.xposed.XC_MethodHook.MethodHookParam
 import rx.Emitter
 import rx.Observable
@@ -87,6 +89,7 @@ import java.util.WeakHashMap
 import j0.l.a.i.a as BaseEmitter
 
 private const val BYPASS_SLOWMODE_PERMISSION = 1L shl 52
+private const val MAX_CHAT_INPUT_LENGTH = 8000
 
 /**
  * Contains various fixes for stock Discord that ensure "proper" behavior.
@@ -123,6 +126,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
         fixUnreadForumChannels()
         fixMemoryLeak()
         fixBottomSheetCallbacks()
+        fixChatInputCharacterLimit()
     }
 
     private val WidgetChatList.binding by accessField<FragmentViewBindingDelegate<WidgetChatListBinding>?>($$"binding$delegate")
@@ -665,6 +669,15 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
                 })
             }, backpressureMode)
             return@instead observable
+        }
+    }
+
+    private fun fixChatInputCharacterLimit() = tryPatch("Cap chat input length to prevent paste freeze") {
+        patcher.after<WidgetChatInputEditText>(
+            FlexEditText::class.java,
+            MessageDraftsRepo::class.java,
+        ) { (_, editText: FlexEditText) ->
+            editText.filters += InputFilter.LengthFilter(MAX_CHAT_INPUT_LENGTH)
         }
     }
 

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -151,8 +151,8 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
     private fun fixStockEmojis() = tryPatch("Fix built-in emojis") {
         // Patch to repair built-in emotes is needed because installer doesn't recompile resources,
         // so they stay in package com.discord instead of apk package name
-        patcher.instead<ModelEmojiUnicode?>("getImageUri", String::class.java, Context::class.java) { param ->
-            "res:///${Utils.getResId("emoji_${param.args[0]}", "raw")}"
+        patcher.instead<ModelEmojiUnicode?>("getImageUri", String::class.java, Context::class.java) { (_, name: String) ->
+            "res:///${Utils.getResId("emoji_$name", "raw")}"
         }
     }
 
@@ -236,7 +236,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
 
             val size = IconUtils.getMediaProxySize(bindingGuild.d.layoutParams.height)
             val url = IconUtils.getForGuild(guild, null, animated) + "&size=${size}"
-            MGImages.`setImage$default`(bindingGuild.d, url, size, size, false, null, null, 112, null);
+            MGImages.`setImage$default`(bindingGuild.d, url, size, size, false, null, null, 112, null)
         }
 
         // Support webp emojis by forcing every emoji to be webp
@@ -324,8 +324,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
             IntArray::class.java,
             Int::class.javaPrimitiveType!!,
             Long::class.javaPrimitiveType!!,
-        ) { param ->
-            val durations = param.args[4] as IntArray
+        ) { (_, _: Int, _: Int, _: Int, _: Int, durations: IntArray) ->
             durations.forEachIndexed { index, duration ->
                 if (duration <= 10) durations[index] = 100
             }
@@ -384,6 +383,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
 
             if (!model.isGuildSelected && model.items.size > 1) {
                 val manager = WidgetChannelsList.`access$getBinding$p`(this).c.layoutManager as LinearLayoutManager
+
                 if (manager.findFirstVisibleItemPosition() != 0) {
                     executed = true
                     manager.scrollToPosition(0)
@@ -481,6 +481,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
 
             val channel = StoreStream.getChannelsSelected().selectedChannel
             val permissions = StoreStream.getPermissions().permissionsByChannel[channel.id]
+
             if (PermissionUtils.INSTANCE.hasBypassSlowmodePermissions(permissions, StoreSlowMode.Type.MessageSend.INSTANCE)) {
                 param.result = Utils.appContext.resources.getString(R.h.channel_slowmode_desc_immune)
             }
@@ -494,6 +495,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
             val intent = param.args[0] as? Intent ?: return
             val pm = Utils.appContext.packageManager
             val handlers = pm.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
+
             if (handlers.isEmpty()) intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
 
@@ -536,12 +538,10 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
         patcher.before<UserProfileHeaderView>(
             "updateBannerColor",
             UserProfileHeaderViewModel.ViewState.Loaded::class.java,
-        ) { param ->
+        ) { (param, state: UserProfileHeaderViewModel.ViewState.Loaded) ->
             if (Looper.myLooper() == Looper.getMainLooper()) return@before
 
-            val view = param.thisObject as UserProfileHeaderView
-            val state = param.args[0] as UserProfileHeaderViewModel.ViewState.Loaded
-            Utils.mainThread.post { view.updateBannerColor(state) }
+            Utils.mainThread.post { updateBannerColor(state) }
             param.result = null
         }
     }
@@ -564,6 +564,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
             val joinedForumThreadsMap = forumThreadsMap.filter {
                 StoreStream.Companion!!.threadsJoined.getJoinedThread(it.value.id) != null
             }
+
             param.args[7] = joinedForumThreadsMap
         }
     }
@@ -619,6 +620,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
         }
         patcher.before<WidgetExpressionTray>("setUpEmojiPicker") { param ->
             val fragment = childFragmentManager.findFragmentById(expressionTrayPickerId) as? WidgetEmojiPicker
+
             if (isRecreated && fragment != null) {
                 // Manually re-set picker fragment listeners
                 // since original code will always create a new picker instance - Canny
@@ -676,6 +678,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
                     observer?.let { this@instead.disconnect(it) }
                 })
             }, backpressureMode)
+
             return@instead observable
         }
     }
@@ -692,19 +695,17 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
     private val bottomSheetCallbacks = WeakHashMap<BottomSheetBehavior<*>, BottomSheetBehavior.BottomSheetCallback>()
 
     private fun fixBottomSheetCallbacks() = tryPatch("Fix deprecated BottomSheet callback clearing internal callbacks") {
-        patcher.instead<BottomSheetBehavior<*>>(
+        patcher.instead<BottomSheetBehavior<View>>(
             "setBottomSheetCallback",
             BottomSheetBehavior.BottomSheetCallback::class.java,
-        ) { param ->
-            @Suppress("UNCHECKED_CAST")
-            val behavior = param.thisObject as BottomSheetBehavior<View>
-            val callback = param.args[0] as BottomSheetBehavior.BottomSheetCallback?
+        ) { (_, callback: BottomSheetBehavior.BottomSheetCallback?) ->
+            bottomSheetCallbacks.remove(this)?.let(::removeBottomSheetCallback)
 
-            bottomSheetCallbacks.remove(behavior)?.let(behavior::removeBottomSheetCallback)
             if (callback != null) {
-                behavior.addBottomSheetCallback(callback)
-                bottomSheetCallbacks[behavior] = callback
+                addBottomSheetCallback(callback)
+                bottomSheetCallbacks[this] = callback
             }
+
             null
         }
     }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -76,6 +76,7 @@ import com.discord.widgets.user.profile.UserProfileHeaderView
 import com.discord.widgets.user.profile.UserProfileHeaderViewModel
 import com.discord.widgets.user.usersheet.WidgetUserSheet
 import com.discord.widgets.user.usersheet.WidgetUserSheetViewModel
+import com.discord.widgets.voice.fullscreen.WidgetCallFullscreen
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.linecorp.apng.decoder.Apng
 import com.lyft.kronos.KronosClock
@@ -116,6 +117,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
         fixHidingMutedDMs()
         fixPrivateChannelScroll()
         fixVoiceCodec()
+        fixTextInVoiceCrash()
         fixThreads()
         fixThreadsIcon()
         fixSlowmode()
@@ -399,6 +401,12 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
             if (mode == "xsalsa20_poly1305") {
                 param.args[2] = "xsalsa20_poly1305_lite_rtpsize"
             }
+        }
+    }
+
+    private fun fixTextInVoiceCrash() = tryPatch("Fix Text-in-Voice crash in calls") {
+        patcher.before<WidgetCallFullscreen>("transitionActivity") { param ->
+            if (appActivity == null) param.result = null
         }
     }
 

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -75,6 +75,7 @@ import com.discord.widgets.user.profile.UserProfileHeaderView
 import com.discord.widgets.user.profile.UserProfileHeaderViewModel
 import com.discord.widgets.user.usersheet.WidgetUserSheet
 import com.discord.widgets.user.usersheet.WidgetUserSheetViewModel
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.linecorp.apng.decoder.Apng
 import com.lyft.kronos.KronosClock
 import com.lytefast.flexinput.R
@@ -82,6 +83,7 @@ import de.robv.android.xposed.XC_MethodHook.MethodHookParam
 import rx.Emitter
 import rx.Observable
 import rx.subjects.Subject
+import java.util.WeakHashMap
 import j0.l.a.i.a as BaseEmitter
 
 private const val BYPASS_SLOWMODE_PERMISSION = 1L shl 52
@@ -120,6 +122,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
         fixProfileBannerColorCrash()
         fixUnreadForumChannels()
         fixMemoryLeak()
+        fixBottomSheetCallbacks()
     }
 
     private val WidgetChatList.binding by accessField<FragmentViewBindingDelegate<WidgetChatListBinding>?>($$"binding$delegate")
@@ -662,6 +665,26 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
                 })
             }, backpressureMode)
             return@instead observable
+        }
+    }
+
+    private val bottomSheetCallbacks = WeakHashMap<BottomSheetBehavior<*>, BottomSheetBehavior.BottomSheetCallback>()
+
+    private fun fixBottomSheetCallbacks() = tryPatch("Fix deprecated BottomSheet callback clearing internal callbacks") {
+        patcher.instead<BottomSheetBehavior<*>>(
+            "setBottomSheetCallback",
+            BottomSheetBehavior.BottomSheetCallback::class.java,
+        ) { param ->
+            @Suppress("UNCHECKED_CAST")
+            val behavior = param.thisObject as BottomSheetBehavior<View>
+            val callback = param.args[0] as BottomSheetBehavior.BottomSheetCallback?
+
+            bottomSheetCallbacks.remove(behavior)?.let(behavior::removeBottomSheetCallback)
+            if (callback != null) {
+                behavior.addBottomSheetCallback(callback)
+                bottomSheetCallbacks[behavior] = callback
+            }
+            null
         }
     }
 

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -197,8 +197,6 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
     private val GuildListViewHolder.GuildViewHolder.bindingGuild
         by accessField<WidgetGuildsListItemGuildBinding>()
 
-    private val guildIconUrls = WeakHashMap<View, String>()
-
     private fun patchIconU(name: String, vararg paramTypes: Class<*>) {
         patcher.patch(IconUtils::class.java.getDeclaredMethod(name, *paramTypes)) {
             it.result = (it.result as? String)
@@ -234,22 +232,11 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
             "configureGuildIconImage",
             Guild::class.java, Boolean::class.javaPrimitiveType!!,
         ) { (_, guild: Guild, animated: Boolean) ->
-            val icon = bindingGuild.d
+            if (!guild.hasIcon()) return@after
 
-            if (!guild.hasIcon()) {
-                guildIconUrls -= icon
-                return@after
-            }
-
-            val size = icon.layoutParams.height.takeIf { it > 0 }
-                ?.let(IconUtils::getMediaProxySize)
-                ?: return@after
-
+            val size = IconUtils.getMediaProxySize(bindingGuild.d.layoutParams.height)
             val url = IconUtils.getForGuild(guild, null, animated) + "&size=${size}"
-
-            if (guildIconUrls.put(icon, url) == url) return@after
-
-            MGImages.`setImage$default`(icon, url, size, size, false, null, null, 112, null)
+            MGImages.`setImage$default`(bindingGuild.d, url, size, size, false, null, null, 112, null)
         }
 
         // Support webp emojis by forcing every emoji to be webp

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -89,7 +89,7 @@ import java.util.WeakHashMap
 import j0.l.a.i.a as BaseEmitter
 
 private const val BYPASS_SLOWMODE_PERMISSION = 1L shl 52
-private const val MAX_CHAT_INPUT_LENGTH = 8000
+private const val MAX_CHAT_INPUT_LENGTH = 64000
 
 /**
  * Contains various fixes for stock Discord that ensure "proper" behavior.

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/DefaultStickers.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/DefaultStickers.kt
@@ -74,7 +74,7 @@ internal class DefaultStickers : CorePlugin(Manifest("DefaultStickers")) {
         patcher.before<`MessageQueue$doSend$2`<*, *>>("call", SendUtils.SendPayload.ReadyToSend::class.java) { (it, payload: SendUtils.SendPayload.ReadyToSend) ->
             if (!UserUtils.INSTANCE.getCanUsePremiumStickers(StoreStream.getUsers().me)) {
                 val message = payload.message
-                if (message.stickerIds.isNotEmpty()) {
+                if (!message.stickerIds.isNullOrEmpty()) {
                     it.result = BehaviorSubject.l0(Http.Request.newDiscordRNRequest("/channels/${`$message`.channelId}/messages", "POST").executeWithJson(GsonUtils.gsonRestApi, message).json(GsonUtils.gsonRestApi, Message::class.java))
                 }
             }


### PR DESCRIPTION
## the fixing

**1. Profile banner color thread crash**
`CalledFromWrongThreadException` when opening a profile. Fresco runs on a background thread and calls `updateBannerColor` and `setBackgroundColor`, which area on the main thread

**2. DefaultStickers send NPE**
`NullPointerException` on `Collection.isEmpty()` while sending a message

**3. BottomSheet callback warning**
`BottomSheetBehavior.setBottomSheetCallback()`, used by `AppBottomSheet.onViewCreated`, is deprecated

**4. Storage perms dialog span crash**
`Utils.launchFileExplorer` builds a `SpannableStringBuilder` and calls `setSpan` at `text.indexOf(substring)`
When the label is missing, it throws an `IndexOutOfBoundsException` because `indexOf` == `-1`

**5. Limit message length to prevent freezes**
`EditText` has no character limit, so pasting a very large wall of text into it freezes the app completely

**6. Fix crash on "NEW! Text chat in voice" popup crash**
When you click on "Try it" right as the popup shows, the activity is `null`, you must wait a while for it to load in the background, then it becomes `com.discord.app.AppActivity$Call@...`

<details>
<summary>image preview of that popup</summary>

<img width="1280" height="2856" alt="text chat in voice crash" src="https://github.com/user-attachments/assets/cb7ecc11-2f3e-419f-8ce9-537366f22dcb" />
</details>
