### PR TITLE
fix: opt the injected app out of Android 16+ automatic Expanded dark theming

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -99,6 +99,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
         fixStockEmojis()
         fixAutoModEmbed()
         fixKeyboardCrash()
+        fixForceDark()
         fixAnimatedWebp()
         fixAnimatedPreviews()
         fixMemberListGroups()
@@ -177,6 +178,16 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
                     WindowInsetsAnimation.Bounds::class.java
                 ) { (param, animation: WindowInsetsAnimation) ->
                     if (animation.durationMillis < 0) param.result = param.args[1]
+                }
+            }
+        }
+    }
+
+    private fun fixForceDark() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            tryPatch("Fix force-dark theming") {
+                patcher.after<Activity>("onCreate", Bundle::class.java) { (_, _: Bundle?) ->
+                    window?.setForceDarkAllowed(false)
                 }
             }
         }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt
@@ -187,7 +187,7 @@ internal class CoreFixes : CorePlugin(Manifest("CoreFixes")) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             tryPatch("Fix force-dark theming") {
                 patcher.after<Activity>("onCreate", Bundle::class.java) { (_, _: Bundle?) ->
-                    window?.setForceDarkAllowed(false)
+                    window?.decorView?.setForceDarkAllowed(false)
                 }
             }
         }


### PR DESCRIPTION
## Summary

Opts the injected app out of Android 16+ automatic "Expanded" (force-dark / "smart dark") theming so the system stops re-tinting UI surfaces it should not, which was producing the guild-tag icon rendering artifact reported in #743.

## Why this matters

On Android 16 QPR2 / Android 17 the system applies force-dark to apps that have not explicitly opted out. Applied to the injected Discord app this re-tints surfaces and causes the visible guild-tag icon bug. The reporter confirmed that disabling force-dark removes the artifact, and keeping the fix at runtime avoids any Manager/manifest change.

The fix lives in the existing `CoreFixes` core plugin (`Aliucord/src/main/java/com/aliucord/coreplugins/CoreFixes.kt`). A new `fixForceDark()` patch hooks the host `Activity.onCreate` and calls `setForceDarkAllowed(false)` on the window decor view. `View.setForceDarkAllowed(boolean)` exists since API 29, so the call is gated on `Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q`; older devices skip it entirely. The body runs inside the existing `tryPatch` helper, so any failure is caught and logged rather than affecting startup.

## Testing

No build was run locally (no Android SDK/JDK in this environment). The change is a single SDK-gated patch added to the already-registered `CoreFixes` plugin, following the existing `patcher.after<Activity>(...)` pattern used by `fixExternalLinks`. Manual verification on an Android 16 QPR2 / 17 device with system Expanded dark theme active should show the guild-tag icons rendering correctly.

Fixes #743
