### PR TITLE
feat(builds): deploy contributors data

### DIFF
--- a/.github/workflows/fetch-contributors.yml
+++ b/.github/workflows/fetch-contributors.yml
@@ -1,0 +1,82 @@
+name: Fetch and Cache Contributors
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+jobs:
+  fetch-contributors:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout builds branch
+      uses: actions/checkout@v4
+      with:
+        ref: builds
+    - name: Fetch and Format Contributors
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        OUTPUT_FILE="all_contributors.json"
+        echo "[]" > $OUTPUT_FILE
+        
+        ORG_NAME="Aliucord"
+        echo "Discovering repositories for organization: $ORG_NAME..."
+        REPOS_JSON=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github+json" \
+          "https://api.github.com/orgs/$ORG_NAME/repos?per_page=100&type=public")
+        if echo "$REPOS_JSON" | jq empty; then
+          REPOS=($(echo "$REPOS_JSON" | jq -r '.[] | select(.fork == false) | .full_name'))
+          echo "Found ${#REPOS[@]} repositories to scan."
+        else
+          echo "::error:: Failed to fetch repository listing for organization $ORG_NAME"
+          exit 1
+        fi
+        for REPO in "${REPOS[@]}"; do
+          echo "Fetching contributors for $REPO..."
+          
+          RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/contributors?per_page=100")
+            
+          if echo "$RESPONSE" | jq empty; then
+            FORMATTED_DATA=$(echo "$RESPONSE" | jq --arg repo "$REPO" '
+              [ .[] | 
+                select(.type == "User" and .login != "actions-user" and .login != "crowdin-bot") | 
+                {
+                  username: .login, 
+                  avatarUrl: .avatar_url, 
+                  commits: .contributions, 
+                  repositories: [{name: $repo, commits: .contributions}]
+                }
+              ]')
+            
+            jq -s '
+              (.[0] + .[1]) |
+              group_by(.username) |
+              map({
+                username: .[0].username,
+                avatarUrl: .[0].avatarUrl,
+                commits: map(.commits) | add,
+                repositories: map(.repositories) | add
+              })
+            ' $OUTPUT_FILE <(echo "$FORMATTED_DATA") > temp.json
+            mv temp.json $OUTPUT_FILE
+          else
+            echo "::error:: Failed to fetch or parse JSON for $REPO"
+          fi
+        done
+        
+        echo "Data successfully structured inside $OUTPUT_FILE"
+    - name: Commit and Push to builds branch
+      run: |
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git add -f all_contributors.json
+        
+        if ! git diff-index --quiet HEAD; then
+          git commit -m "chore: automated update of cached contributors"
+          git push origin builds
+        else
+          echo "No changes detected in contributor counts. Skipping commit."
+        fi

--- a/.github/workflows/fetch-contributors.yml
+++ b/.github/workflows/fetch-contributors.yml
@@ -1,82 +1,83 @@
-name: Fetch and Cache Contributors
+name: Fetch Contributors
+
 on:
   schedule:
-    - cron: '0 0 1 * *'
+    - cron: '0 0 1 * *' # “At 00:00 on day-of-month 1.”
+  push:
+    branches: [ main ]
+    paths: .github/workflows/fetch-contributors.yml
   workflow_dispatch:
+
 jobs:
   fetch-contributors:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     permissions:
       contents: write
     steps:
-    - name: Checkout builds branch
-      uses: actions/checkout@v4
-      with:
-        ref: builds
-    - name: Fetch and Format Contributors
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        OUTPUT_FILE="all_contributors.json"
-        echo "[]" > $OUTPUT_FILE
-        
-        ORG_NAME="Aliucord"
-        echo "Discovering repositories for organization: $ORG_NAME..."
-        REPOS_JSON=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-          -H "Accept: application/vnd.github+json" \
-          "https://api.github.com/orgs/$ORG_NAME/repos?per_page=100&type=public")
-        if echo "$REPOS_JSON" | jq empty; then
-          REPOS=($(echo "$REPOS_JSON" | jq -r '.[] | select(.fork == false) | .full_name'))
-          echo "Found ${#REPOS[@]} repositories to scan."
-        else
-          echo "::error:: Failed to fetch repository listing for organization $ORG_NAME"
-          exit 1
-        fi
-        for REPO in "${REPOS[@]}"; do
-          echo "Fetching contributors for $REPO..."
-          
-          RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+      - name: Checkout builds
+        uses: actions/checkout@v7
+        with:
+          ref: builds
+
+      - name: Fetch & Update Contributors
+        env:
+          ORG: Aliucord
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Discovering repositories for organization: $ORG..."
+          RESPONSE=$(curl -sL --fail-with-body \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/$REPO/contributors?per_page=100")
-            
-          if echo "$RESPONSE" | jq empty; then
-            FORMATTED_DATA=$(echo "$RESPONSE" | jq --arg repo "$REPO" '
-              [ .[] | 
-                select(.type == "User" and .login != "actions-user" and .login != "crowdin-bot") | 
-                {
-                  username: .login, 
-                  avatarUrl: .avatar_url, 
-                  commits: .contributions, 
-                  repositories: [{name: $repo, commits: .contributions}]
+            "https://api.github.com/orgs/$ORG/repos?per_page=100&type=public")
+
+          REPOS=($(echo "$RESPONSE" | jq -r '.[] | select(.fork == false) | .full_name'))
+          TMP=$(mktemp -d)
+
+          for REPO in "${REPOS[@]}"; do
+            echo "Fetching contributors for $REPO..."
+
+            RESPONSE=$(curl -sL --fail-with-body \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/contributors?per_page=100")
+
+            echo "$RESPONSE" | jq --raw-output --compact-output --arg repo "$REPO" '
+              [ .[]
+                | select(.type == "User" and
+                       .login != "actions-user" and
+                       .login != "crowdin-bot")
+                | {
+                  username: .login,
+                  avatarUrl: .avatar_url,
+                  commits: .contributions,
+                  repositories: [{ name: $repo, commits: .contributions }]
                 }
-              ]')
-            
-            jq -s '
-              (.[0] + .[1]) |
-              group_by(.username) |
-              map({
-                username: .[0].username,
-                avatarUrl: .[0].avatarUrl,
-                commits: map(.commits) | add,
-                repositories: map(.repositories) | add
+              ]' > "$(mktemp -p $TMP --suffix=.json)"
+          done
+
+          echo "Combining all fetched records..."
+          jq --slurp --compact-output '.
+            | flatten
+            | group_by(.username)
+            | map({
+              username: .[0].username,
+              avatarUrl: .[0].avatarUrl,
+              commits: map(.commits) | add,
+              repositories: map(.repositories)
+                 | add
+                 | sort_by(-.commits, .name)
               })
-            ' $OUTPUT_FILE <(echo "$FORMATTED_DATA") > temp.json
-            mv temp.json $OUTPUT_FILE
-          else
-            echo "::error:: Failed to fetch or parse JSON for $REPO"
+            | sort_by(-.commits, .username)
+          ' $TMP/*.json > contributors.json
+
+      - name: Deploy Data
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add contributors.json
+
+          if [[ `git status --porcelain` ]]; then
+            git commit -m "chore: update contributors"
+            git push
           fi
-        done
-        
-        echo "Data successfully structured inside $OUTPUT_FILE"
-    - name: Commit and Push to builds branch
-      run: |
-        git config --local user.email "github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
-        git add all_contributors.json
-        
-        if ! git diff-index --quiet HEAD; then
-          git commit -m "chore: automated update of cached contributors"
-          git push origin builds
-        else
-          echo "No changes detected in contributor counts. Skipping commit."
-        fi

--- a/.github/workflows/fetch-contributors.yml
+++ b/.github/workflows/fetch-contributors.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         git config --local user.email "github-actions[bot]@users.noreply.github.com"
         git config --local user.name "github-actions[bot]"
-        git add -f all_contributors.json
+        git add all_contributors.json
         
         if ! git diff-index --quiet HEAD; then
           git commit -m "chore: automated update of cached contributors"


### PR DESCRIPTION
This adds a Github workflow file to fetch contributors from all repositories in Aliucord and output a json file with every contributor, number of commits, repositories and avatar url to the `builds` branch. Mainly to be used to fix the Contributors list in the About Screen of Aliucord Manager.

PRing again because my git instance was too screwed up and I forgot to include a description last time.