### PR TITLE
fix(patches): switch GIF provider to Klipy

### DIFF
--- a/patches/src/com/discord/stores/StoreGifPicker.patch
+++ b/patches/src/com/discord/stores/StoreGifPicker.patch
@@ -1,0 +1,46 @@
+--- smali_original/com/discord/stores/StoreGifPicker.smali
++++ smali/com/discord/stores/StoreGifPicker.smali
+@@ -793,7 +793,7 @@
+
+     move-result-object v2
+
+-    const-string/jumbo v3, "tenor"
++    const-string/jumbo v3, "klipy"
+
+     const/4 v4, 0x5
+
+@@ -855,7 +855,7 @@
+
+     move-result-object v3
+
+-    const-string/jumbo v2, "tenor"
++    const-string/jumbo v2, "klipy"
+
+     const-string/jumbo v4, "tinygif"
+
+@@ -934,7 +934,7 @@
+
+     move-result-object v1
+
+-    const-string/jumbo v2, "tenor"
++    const-string/jumbo v2, "klipy"
+
+     const/4 v3, 0x5
+
+@@ -1003,7 +1003,7 @@
+
+     move-result-object v2
+
+-    const-string/jumbo v3, "tenor"
++    const-string/jumbo v3, "klipy"
+
+     const-string/jumbo v4, "tinygif"
+
+@@ -1629,7 +1629,7 @@
+
+     move-result-object v2
+
+-    const-string/jumbo v3, "tenor"
++    const-string/jumbo v3, "klipy"
+
+     const-string/jumbo v4, "tinygif"


### PR DESCRIPTION
Tenor API shut down June 30, 2026. Discord already migrated their servers to accept provider=klipy. This patch replaces the 5 hardcoded `"tenor"` strings in `StoreGifPicker` with `"klipy"` so GIF search keeps working.

Verified with `testPatches` - all patches apply cleanly. Tested on device via custom patches import.