### PR TITLE
feat(rn): handle RN spoilers

### DIFF
--- a/Aliucord/src/main/java/com/aliucord/coreplugins/rn/Patches.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/rn/Patches.kt
@@ -294,7 +294,7 @@ val MessageAttachment.flags: Int by accessField();
 fun patchSpoilers(){
     Patcher.addPatch(MessageAttachment::class.java.getDeclaredMethod("h"/*"isSpoiler"*/), Hook {
         val isSpoiler = it.result as Boolean
-        if (isSpoiler || frame.thisObject == null) return@Hook
+        if (isSpoiler || it.thisObject == null) return@Hook
         with (it.thisObject as MessageAttachment) {
             it.result = (0 != (flags and 8/*MessageAttachment.SPOILER*/))
         }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/rn/Patches.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/rn/Patches.kt
@@ -11,10 +11,12 @@ import android.net.Uri
 import android.view.View
 import com.aliucord.api.rn.user.RNUserProfile
 import com.aliucord.patcher.*
+import com.aliucord.utils.accessField
 import com.aliucord.wrappers.embeds.MessageEmbedWrapper.Companion.rawVideo
 import com.aliucord.wrappers.users.globalName
 import com.discord.api.channel.Channel
 import com.discord.api.channel.`ChannelUtils$getDisplayName$1`
+import com.discord.api.message.attachment.MessageAttachment
 import com.discord.api.message.embed.EmbedType
 import com.discord.api.message.embed.MessageEmbed
 import com.discord.api.role.GuildRoleColors
@@ -284,6 +286,17 @@ fun patchAuditLog() {
                 }
             }
             it.result = colors
+        }
+    })
+}
+
+val MessageAttachment.flags: Int by accessField();
+fun patchSpoilers(){
+    Patcher.addPatch(MessageAttachment::class.java.getDeclaredMethod("h"/*"isSpoiler"*/), Hook {
+        val isSpoiler = it.result as Boolean
+        if (isSpoiler || frame.thisObject == null) return@Hook
+        with (it.thisObject as MessageAttachment) {
+            it.result = (0 != (flags and 8/*MessageAttachment.SPOILER*/))
         }
     })
 }

--- a/Aliucord/src/main/java/com/aliucord/coreplugins/rn/RNAPI.kt
+++ b/Aliucord/src/main/java/com/aliucord/coreplugins/rn/RNAPI.kt
@@ -31,6 +31,8 @@ internal class RNAPI : CorePlugin(Manifest("RNAPI")) {
 
         if (ManagerBuild.hasInjector("2.1.2")) patchAuditLog()
         else logger.warn("Base app outdated, cannot patch audit log")
+        if (ManagerBuild.hasInjector("2.4.0")) patchSpoilers()
+        else logger.warn("Base app outdated, cannot patch attachment spoilers")
     }
 
     override fun start(context: Context) {}


### PR DESCRIPTION
Discord adding some bullshit, spoilered attachments now might be marked with a flag (`1<<3`) and not have `SPOILER_` in the filename at all